### PR TITLE
Feature/gui fixes

### DIFF
--- a/src/gui/analysis/captured.py
+++ b/src/gui/analysis/captured.py
@@ -45,7 +45,7 @@ class CapturedPiecesWidget(QFrame):
         # enough that the piece symbols are easy to read.
         self.setMinimumHeight(56)
         self.setMaximumHeight(56)
-
+        
     def update_captured(self, fen):
         """Update captured pieces display based on current FEN.
 
@@ -88,37 +88,60 @@ class CapturedPiecesWidget(QFrame):
         diff = white_score - black_score  # positive = White is ahead in material
 
         if self.side == "white":
-            # Black pieces White has taken.
+            # Black pieces White has taken — show with INVERTED background
+            # (dark piece on light chip).
             ordered = ['q', 'r', 'b', 'n', 'p']
             for p in ordered:
                 if p in white_caps:
-                    self._add_pieces(white_caps[p], p, Styles.COLOR_PIECE_BLACK)
+                    self._add_pieces(
+                        white_caps[p], p,
+                        fg=Styles.COLOR_PIECE_BLACK,
+                        bg=Styles.COLOR_PIECE_WHITE,
+                    )
             if diff > 0:
                 self._add_advantage_label(f"+{diff}")
-        else:  # "black" — white pieces Black has taken
+        else:  # "black" — white pieces Black has taken (light piece on dark chip)
             ordered = ['Q', 'R', 'B', 'N', 'P']
             for p in ordered:
                 if p in black_caps:
-                    self._add_pieces(black_caps[p], p, Styles.COLOR_PIECE_WHITE)
+                    self._add_pieces(
+                        black_caps[p], p,
+                        fg=Styles.COLOR_PIECE_WHITE,
+                        bg=Styles.COLOR_PIECE_BLACK,
+                    )
             if diff < 0:
                 self._add_advantage_label(f"+{-diff}")
 
-    def _add_pieces(self, count, piece, color):
-        """Add piece symbols to the layout."""
+    def _add_pieces(self, count, piece, fg, bg):
+        """Add piece symbols to layout as chips with an inverted background.
+
+        The chip background (bg) is the inverse of the piece's foreground
+        colour (fg), so a dark piece gets a light chip and vice versa.
+        """
         piece_map = {
             'p': '♟', 'n': '♞', 'b': '♝', 'r': '♜', 'q': '♛',
             'P': '♟', 'N': '♞', 'B': '♝', 'R': '♜', 'Q': '♛',
         }
 
+        style = (
+            f"color: {fg}; background-color: {bg};"
+            f" font-size: 26px; padding: 2px 6px; border-radius: 4px;"
+        )
         for _ in range(count):
             lbl = QLabel(piece_map.get(piece, '?'))
-            lbl.setStyleSheet(f"color: {color}; font-size: 18px;")
+            lbl.setStyleSheet(style)
             self.pieces_layout.addWidget(lbl)
 
     def _add_advantage_label(self, text):
-        """Append a material-advantage label to the end of the row."""
+        """Insert the material-advantage chip at the LEFT (index 0) so the
+        counter stays pinned to the start of the row and does not wander
+        as new pieces are captured."""
         lbl = QLabel(text)
         lbl.setStyleSheet(
-            f"color: {Styles.COLOR_TEXT_PRIMARY}; font-weight: bold;"
+            f"color: {Styles.COLOR_TEXT_PRIMARY};"
+            f" background-color: {Styles.COLOR_SURFACE_LIGHT};"
+            f" font-weight: bold; font-size: 16px;"
+            f" padding: 4px 8px; border-radius: 4px;"
+            f" margin-right: 4px;"
         )
-        self.pieces_layout.addWidget(lbl)
+        self.pieces_layout.insertWidget(0, lbl)

--- a/src/gui/analysis/captured.py
+++ b/src/gui/analysis/captured.py
@@ -16,6 +16,19 @@ class CapturedPiecesWidget(QFrame):
     surrounding layout — one above the board, one below.
     """
 
+    # Unicode superscript digits used for the compact pawn-count chip.
+    # We avoid HTML <sup> because QLabel's rich-text layout reserved a
+    # separate box for the digit and pushed the piece symbol down so
+    # it no longer lined up with the other piece chips beside it.
+    # The font's built-in superscript glyphs are already ~70% the
+    # size of a normal digit, which gives a small raised count for
+    # free without any inline-CSS that would fight the label's own
+    # font-size rule.
+    _SUP_MAP = {
+        '0': '⁰', '1': '¹', '2': '²', '3': '³', '4': '⁴',
+        '5': '⁵', '6': '⁶', '7': '⁷', '8': '⁸', '9': '⁹',
+    }
+
     def __init__(self, side: str = "white"):
         super().__init__()
         self.side = side  # "white" or "black" — which player's captures this shows
@@ -113,10 +126,16 @@ class CapturedPiecesWidget(QFrame):
                 self._add_advantage_label(f"+{-diff}")
 
     def _add_pieces(self, count, piece, fg, bg):
-        """Add piece symbols to layout as chips with an inverted background.
+        """Add piece chips for the given count.
 
-        The chip background (bg) is the inverse of the piece's foreground
-        colour (fg), so a dark piece gets a light chip and vice versa.
+        Pawns (the only piece type with up to 8 copies) are shown as
+        a single compact chip with a superscript count, e.g. "♟³"
+        for three captured pawns. This keeps the captured-pieces row
+        narrow so it does not stretch the chess board horizontally.
+
+        Every other piece type has at most 2 copies, so they keep the
+        original per-piece chip layout — visually consistent with the
+        piece shapes and the compact-pawn notation.
         """
         piece_map = {
             'p': '♟', 'n': '♞', 'b': '♝', 'r': '♜', 'q': '♛',
@@ -127,10 +146,38 @@ class CapturedPiecesWidget(QFrame):
             f"color: {fg}; background-color: {bg};"
             f" font-size: 26px; padding: 2px 6px; border-radius: 4px;"
         )
-        for _ in range(count):
-            lbl = QLabel(piece_map.get(piece, '?'))
+
+        symbol = piece_map.get(piece, '?')
+        if piece in ('p', 'P'):
+            # Pawns only: one chip with a small raised count.
+            # A count of 1 is shown as just the symbol — cleaner than
+            # "♟¹" and saves a bit of horizontal room.
+            #
+            # We use Unicode superscript digits (⁰¹²³⁴⁵⁶⁷⁸⁹) rather
+            # than HTML <sup> for two reasons:
+            #   1. With <sup>, QLabel's rich-text layout reserved a
+            #      separate box for the digit that pushed the piece
+            #      symbol down so it no longer lined up with the other
+            #      piece chips beside it.
+            #   2. The font's built-in superscript glyphs are already
+            #      ~70% the size of a normal digit, so we get a small
+            #      raised count without any inline-CSS hack that
+            #      conflicts with the label's 26 px font-size.
+            if count > 1:
+                sup_digits = ''.join(self._SUP_MAP[d] for d in str(count))
+                text = f"{symbol}{sup_digits}"
+            else:
+                text = symbol
+            lbl = QLabel(text)
             lbl.setStyleSheet(style)
             self.pieces_layout.addWidget(lbl)
+        else:
+            # Knights, bishops, rooks, queens: one chip per piece
+            # (max 2 per type, so width stays bounded).
+            for _ in range(count):
+                lbl = QLabel(symbol)
+                lbl.setStyleSheet(style)
+                self.pieces_layout.addWidget(lbl)
 
     def _add_advantage_label(self, text):
         """Insert the material-advantage chip at the LEFT (index 0) so the

--- a/src/gui/analysis/captured.py
+++ b/src/gui/analysis/captured.py
@@ -8,11 +8,18 @@ from ..gui_utils import clear_layout
 
 
 class CapturedPiecesWidget(QFrame):
-    """Widget to display captured pieces for both players."""
-    
-    def __init__(self):
+    """Widget to display captured pieces for ONE player side.
+
+    The white-player variant shows the black pieces White has taken
+    (i.e. what is missing from Black). The black-player variant shows
+    the white pieces Black has taken. Use two of these widgets in the
+    surrounding layout — one above the board, one below.
+    """
+
+    def __init__(self, side: str = "white"):
         super().__init__()
-        self.setFrameStyle(QFrame.Shape.StyledPanel | QFrame.Shadow.Raised)
+        self.side = side  # "white" or "black" — which player's captures this shows
+        self.setFrameStyle(QFrame.Shape.StyledPanel | QFrame.Shape.NoFrame)
         self.setStyleSheet(f"""
             QFrame {{
                 background-color: {Styles.COLOR_SURFACE};
@@ -22,24 +29,32 @@ class CapturedPiecesWidget(QFrame):
             }}
             {Styles.CAPTURED_PIECES_STYLE}
         """)
-        
-        layout = QVBoxLayout(self)
+
+        layout = QHBoxLayout(self)
         layout.setSpacing(5)
         layout.setContentsMargins(5, 5, 5, 5)
-        
-        self.white_captured_layout = QHBoxLayout()
-        self.white_captured_layout.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        layout.addLayout(self.white_captured_layout)
-        
-        self.black_captured_layout = QHBoxLayout()
-        self.black_captured_layout.setAlignment(Qt.AlignmentFlag.AlignLeft)
-        layout.addLayout(self.black_captured_layout)
-        
+        layout.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+
+        self.pieces_layout = QHBoxLayout()
+        self.pieces_layout.setSpacing(2)
+        self.pieces_layout.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+        layout.addLayout(self.pieces_layout)
+
+        # Reserve a fixed, content-independent height so the board does
+        # not shift when the first piece gets captured. Sized large
+        # enough that the piece symbols are easy to read.
+        self.setMinimumHeight(56)
+        self.setMaximumHeight(56)
+
     def update_captured(self, fen):
-        """Update captured pieces display based on current FEN."""
-        clear_layout(self.white_captured_layout)
-        clear_layout(self.black_captured_layout)
-        
+        """Update captured pieces display based on current FEN.
+
+        This widget only displays the captures belonging to the configured
+        side (self.side). The companion widget on the opposite side is
+        expected to be called with the same FEN.
+        """
+        clear_layout(self.pieces_layout)
+
         if not fen:
             return
 
@@ -47,48 +62,63 @@ class CapturedPiecesWidget(QFrame):
             'p': 8, 'n': 2, 'b': 2, 'r': 2, 'q': 1,
             'P': 8, 'N': 2, 'B': 2, 'R': 2, 'Q': 1
         }
-        
+
         current_pieces = {}
         board_part = fen.split(' ')[0]
         for char in board_part:
             if char.isalpha():
                 current_pieces[char] = current_pieces.get(char, 0) + 1
-                
+
         piece_values = {'p': 1, 'n': 3, 'b': 3, 'r': 5, 'q': 9}
-        
-        white_score = 0
-        black_score = 0
-        
+
+        # Pieces taken BY white (lowercase = black pieces missing) and BY black.
+        white_caps = {}  # black pieces White has taken
+        black_caps = {}  # white pieces Black has taken
         for p in ['p', 'n', 'b', 'r', 'q']:
             count = starting_pieces[p] - current_pieces.get(p, 0)
             if count > 0:
-                self._add_pieces(self.white_captured_layout, p, count, Styles.COLOR_PIECE_BLACK)
-                white_score += count * piece_values[p]
-                
+                white_caps[p] = count
         for p in ['P', 'N', 'B', 'R', 'Q']:
             count = starting_pieces[p] - current_pieces.get(p, 0)
             if count > 0:
-                self._add_pieces(self.black_captured_layout, p, count, Styles.COLOR_PIECE_WHITE)
-                black_score += count * piece_values[p.lower()]
-                
-        diff = white_score - black_score
-        if diff > 0:
-            lbl = QLabel(f"+{diff}")
-            lbl.setStyleSheet(f"color: {Styles.COLOR_TEXT_PRIMARY}; font-weight: bold;")
-            self.white_captured_layout.addWidget(lbl)
-        elif diff < 0:
-            lbl = QLabel(f"+{-diff}")
-            lbl.setStyleSheet(f"color: {Styles.COLOR_TEXT_PRIMARY}; font-weight: bold;")
-            self.black_captured_layout.addWidget(lbl)
+                black_caps[p] = count
 
-    def _add_pieces(self, layout, piece, count, color):
-        """Add piece symbols to layout."""
+        white_score = sum(piece_values[p] * c for p, c in white_caps.items())
+        black_score = sum(piece_values[p.lower()] * c for p, c in black_caps.items())
+        diff = white_score - black_score  # positive = White is ahead in material
+
+        if self.side == "white":
+            # Black pieces White has taken.
+            ordered = ['q', 'r', 'b', 'n', 'p']
+            for p in ordered:
+                if p in white_caps:
+                    self._add_pieces(white_caps[p], p, Styles.COLOR_PIECE_BLACK)
+            if diff > 0:
+                self._add_advantage_label(f"+{diff}")
+        else:  # "black" — white pieces Black has taken
+            ordered = ['Q', 'R', 'B', 'N', 'P']
+            for p in ordered:
+                if p in black_caps:
+                    self._add_pieces(black_caps[p], p, Styles.COLOR_PIECE_WHITE)
+            if diff < 0:
+                self._add_advantage_label(f"+{-diff}")
+
+    def _add_pieces(self, count, piece, color):
+        """Add piece symbols to the layout."""
         piece_map = {
             'p': '♟', 'n': '♞', 'b': '♝', 'r': '♜', 'q': '♛',
-            'P': '♟', 'N': '♞', 'B': '♝', 'R': '♜', 'Q': '♛'
+            'P': '♟', 'N': '♞', 'B': '♝', 'R': '♜', 'Q': '♛',
         }
-        
+
         for _ in range(count):
             lbl = QLabel(piece_map.get(piece, '?'))
             lbl.setStyleSheet(f"color: {color}; font-size: 18px;")
-            layout.addWidget(lbl)
+            self.pieces_layout.addWidget(lbl)
+
+    def _add_advantage_label(self, text):
+        """Append a material-advantage label to the end of the row."""
+        lbl = QLabel(text)
+        lbl.setStyleSheet(
+            f"color: {Styles.COLOR_TEXT_PRIMARY}; font-weight: bold;"
+        )
+        self.pieces_layout.addWidget(lbl)

--- a/src/gui/board/board_widget.py
+++ b/src/gui/board/board_widget.py
@@ -1,4 +1,4 @@
-from PyQt6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLabel, QGridLayout
+from PyQt6.QtWidgets import QWidget, QLabel, QGridLayout
 from PyQt6.QtSvgWidgets import QSvgWidget
 from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtGui import QFont
@@ -15,16 +15,16 @@ class BoardWidget(QWidget):
         self.is_flipped = False # False = White bottom, True = Black bottom
         self.svg_widget = QSvgWidget()
         
-        # Layout: Eval Bar | Board
-        self.layout = QHBoxLayout(self)
-        self.layout.setContentsMargins(0, 0, 0, 0)
-        self.layout.setSpacing(0)
-        
-        self.eval_bar = EvalBarWidget()
-        self.layout.addWidget(self.eval_bar)
+        # No QHBoxLayout: eval_bar and board_container are direct children
+        # of this widget and are positioned manually in resizeEvent /
+        # showEvent. A layout here would override our manual setGeometry
+        # whenever the layout invalidates (e.g. after update_board
+        # redraws the SVG on the first move), which is what caused the
+        # board to lose its square aspect ratio on the first move.
+        self.eval_bar = EvalBarWidget(self)
 
         # Board Container (Stack Layout for Overlays)
-        self.board_container = QWidget()
+        self.board_container = QWidget(self)
         self.board_layout = QGridLayout(self.board_container)
         self.board_layout.setContentsMargins(0, 0, 0, 0)
         self.board_layout.setSpacing(0)
@@ -44,13 +44,15 @@ class BoardWidget(QWidget):
 
         self.board_layout.addWidget(self.overlay_widget, 0, 0)
 
-        self.layout.addWidget(self.board_container)
-        self.layout.setStretch(1, 1) # Board takes remaining space
-        
         self.current_move_index = -1
         self.game_moves = []
 
         self.update_board()
+
+    def showEvent(self, event):
+        """Position eval_bar and board_container the first time we appear."""
+        super().showEvent(event)
+        self._enforce_square_board()
 
     def resizeEvent(self, event):
         """Keep the chessboard square and align the eval bar to its height.

--- a/src/gui/board/board_widget.py
+++ b/src/gui/board/board_widget.py
@@ -1,4 +1,4 @@
-from PyQt6.QtWidgets import QWidget, QLabel, QGridLayout
+from PyQt6.QtWidgets import QWidget, QLabel, QGridLayout, QSizePolicy
 from PyQt6.QtSvgWidgets import QSvgWidget
 from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtGui import QFont
@@ -13,6 +13,13 @@ class BoardWidget(QWidget):
         super().__init__()
         self.board = chess.Board()
         self.is_flipped = False # False = White bottom, True = Black bottom
+        # We need the board to take all available space in its parent
+        # QVBoxLayout cell. Without an inner layout, sizePolicy defaults
+        # to Preferred, which sizes us to sizeHint/minimum and leaves
+        # the rest of the cell empty. Expanding tells the outer layout
+        # to give us all leftover room; _enforce_square_board then
+        # clamps the actual size to a square inside that room.
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         self.svg_widget = QSvgWidget()
         
         # No QHBoxLayout: eval_bar and board_container are direct children

--- a/src/gui/board/board_widget.py
+++ b/src/gui/board/board_widget.py
@@ -22,20 +22,18 @@ class BoardWidget(QWidget):
         
         self.eval_bar = EvalBarWidget()
         self.layout.addWidget(self.eval_bar)
-        
-        self.layout.addWidget(self.eval_bar)
-        
+
         # Board Container (Stack Layout for Overlays)
         self.board_container = QWidget()
         self.board_layout = QGridLayout(self.board_container)
         self.board_layout.setContentsMargins(0, 0, 0, 0)
         self.board_layout.setSpacing(0)
-        
+
         # SVG Widget (Layer 0)
         self.board_layout.addWidget(self.svg_widget, 0, 0)
         self.board_layout.setRowStretch(0, 1)
         self.board_layout.setColumnStretch(0, 1)
-        
+
         # Overlay Widget (Layer 1)
         self.overlay_widget = QWidget()
         self.overlay_widget.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents) # Let clicks pass through
@@ -43,16 +41,44 @@ class BoardWidget(QWidget):
         self.overlay_layout = QGridLayout(self.overlay_widget)
         self.overlay_layout.setContentsMargins(0, 0, 0, 0)
         self.overlay_layout.setSpacing(0)
-        
+
         self.board_layout.addWidget(self.overlay_widget, 0, 0)
-        
+
         self.layout.addWidget(self.board_container)
         self.layout.setStretch(1, 1) # Board takes remaining space
         
         self.current_move_index = -1
         self.game_moves = []
-        
+
         self.update_board()
+
+    def resizeEvent(self, event):
+        """Keep the chessboard square and align the eval bar to its height.
+
+        The eval bar is 24 px wide (set via setFixedWidth) and is positioned
+        on the left. The board container takes the remaining horizontal
+        space, but is clamped to a square (side = min(avail_w, height)) and
+        centered within the available cell. The eval bar's height is set to
+        match the board's side so the two always align visually.
+        """
+        super().resizeEvent(event)
+        self._enforce_square_board()
+
+    def _enforce_square_board(self):
+        eval_w = self.eval_bar.width()  # fixed at 24 px
+        avail_w = max(0, self.width() - eval_w)
+        avail_h = self.height()
+        if avail_w <= 0 or avail_h <= 0:
+            return
+        side = min(avail_w, avail_h)
+        if side <= 0:
+            return
+        x_board = eval_w + (avail_w - side) // 2
+        y_board = (avail_h - side) // 2
+        # Board is a square, centered in the area right of the eval bar.
+        self.board_container.setGeometry(x_board, y_board, side, side)
+        # Eval bar spans the full height of the board, aligned to its top.
+        self.eval_bar.setGeometry(0, y_board, eval_w, side)
 
     def load_game(self, game_analysis):
         self.board = chess.Board()

--- a/src/gui/board/board_widget.py
+++ b/src/gui/board/board_widget.py
@@ -21,7 +21,10 @@ class BoardWidget(QWidget):
         # whenever the layout invalidates (e.g. after update_board
         # redraws the SVG on the first move), which is what caused the
         # board to lose its square aspect ratio on the first move.
-        self.eval_bar = EvalBarWidget(self)
+        # EvalBarWidget.__init__ does not accept a parent kwarg, so we
+        # construct it first and set the parent on the resulting object.
+        self.eval_bar = EvalBarWidget()
+        self.eval_bar.setParent(self)
 
         # Board Container (Stack Layout for Overlays)
         self.board_container = QWidget(self)

--- a/src/gui/graph_widget.py
+++ b/src/gui/graph_widget.py
@@ -15,6 +15,11 @@ class GraphWidget(QWidget):
         self.canvas = FigureCanvas(self.figure)
         self.layout.addWidget(self.canvas)
         self.ax = self.figure.add_subplot(111)
+
+        # Pin the widget height to the figure's intrinsic pixel size so the
+        # graph does not "jump" when sibling widgets (e.g. analysis lines)
+        # change their sizeHint during navigation.
+        self.setFixedHeight(int(self.figure.get_figheight() * self.figure.get_dpi()))
         
         # Initial styling
         self.clear()

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -303,6 +303,11 @@ class MainWindow(QMainWindow):
         center_layout.addWidget(self.captured_black)
         center_layout.addWidget(self.board_widget)
         center_layout.addWidget(self.captured_white)
+        # Board takes all remaining vertical space. Without this, the
+        # board (which now has no inner layout of its own, so no useful
+        # sizeHint) collapses to its minimum size and the window is
+        # dominated by empty space.
+        center_layout.setStretch(1, 1)
         
         self.controls = GameControlsWidget()
         self.controls.first_clicked.connect(self.go_first)

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -276,6 +276,7 @@ class MainWindow(QMainWindow):
         # Center: Board
         center_widget = QWidget()
         center_layout = QVBoxLayout(center_widget)
+        self.center_layout = center_layout  # needed for flip_board()
         center_layout.setContentsMargins(10, 10, 10, 10)
         center_layout.setSpacing(10)
         
@@ -283,12 +284,25 @@ class MainWindow(QMainWindow):
         self.game_info_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.game_info_label.setStyleSheet(f"font-size: 16px; font-weight: bold; color: {Styles.COLOR_TEXT_PRIMARY}; padding: 5px;")
         center_layout.addWidget(self.game_info_label)
-        
-        self.captured_widget = CapturedPiecesWidget()
-        center_layout.addWidget(self.captured_widget)
-        
+
+        # Captured pieces: White sits at the BOTTOM of the board view,
+        # so White's captures (the black pieces White took) belong BELOW
+        # the board. Black sits at the TOP, so Black's captures (the
+        # white pieces Black took) belong ABOVE the board. Keeping each
+        # capture row adjacent to its capturer is the standard convention.
+        self.captured_white = CapturedPiecesWidget(side="white")
+        self.captured_black = CapturedPiecesWidget(side="black")
+        # Backwards-compat alias — some code may still reference the old name.
+        self.captured_widget = self.captured_white
+
         self.board_widget = BoardWidget()
+        # Layout order (indices shown):
+        #   1 captured_black  (above board, near Black)
+        #   2 board
+        #   3 captured_white  (below board, near White)
+        center_layout.addWidget(self.captured_black)
         center_layout.addWidget(self.board_widget)
+        center_layout.addWidget(self.captured_white)
         
         self.controls = GameControlsWidget()
         self.controls.first_clicked.connect(self.go_first)
@@ -533,7 +547,8 @@ class MainWindow(QMainWindow):
         # self.move_list_panel.load_game(game) # REMOVED: Method does not exist
         self.move_list_panel.set_game(game)
         self.analysis_panel.set_game(game)
-        self.captured_widget.update_captured(None)
+        self.captured_white.update_captured(None)
+        self.captured_black.update_captured(None)
         logger.info(f"Game loaded: {game.metadata.white} vs {game.metadata.black}")
 
     def enrich_game_metadata(self, game, source_data):
@@ -755,9 +770,10 @@ class MainWindow(QMainWindow):
                 else:
                     if hasattr(self.board_widget, 'board'):
                         fen = self.board_widget.board.fen()
-            
-            self.captured_widget.update_captured(fen)
-            
+
+            self.captured_white.update_captured(fen)
+            self.captured_black.update_captured(fen)
+
             if 0 <= index < len(moves):
                 move = moves[index]
                 san = move.san
@@ -796,6 +812,19 @@ class MainWindow(QMainWindow):
 
     def flip_board(self):
         self.board_widget.flip_board()
+        # Keep each player's captured-pieces row adjacent to that player.
+        # The board stays at layout index 2; the two capture rows swap
+        # around it. After flipping (White on top, Black on bottom), the
+        # white-captures row moves above the board and the black-captures
+        # row moves below it.
+        self.center_layout.removeWidget(self.captured_white)
+        self.center_layout.removeWidget(self.captured_black)
+        if self.board_widget.is_flipped:
+            self.center_layout.insertWidget(1, self.captured_white)
+            self.center_layout.insertWidget(3, self.captured_black)
+        else:
+            self.center_layout.insertWidget(1, self.captured_black)
+            self.center_layout.insertWidget(3, self.captured_white)
 
     def on_cache_toggled(self, checked):
         self.analyzer.config["use_cache"] = checked


### PR DESCRIPTION
# GUI fixes — Sammel-PR

Bundle of eight related bugfixes and improvements around the
analysis-view layout. The commits build on each other cleanly, but
are grouped into three logical themes for easier review.

## Files changed

| File | +/− |
|---|---|
| `src/gui/analysis/captured.py` | +147 / −49 |
| `src/gui/board/board_widget.py` | +57 / −19 |
| `src/gui/main_window.py` | +42 / −8 |
| `src/gui/graph_widget.py` | +5 / 0 |
| **Total** | **+251 / −76** |

## Overview

### 1. Captured-pieces widget (`captured.py`) — refactor, style, compactness
- `ed53eab` **refactor(gui):** widget is split into two per-side instances (one above, one below the board) with a fixed height of `56 px` so the board no longer jumps on the first capture.
- `c9d6a03` **style(gui):** chip backgrounds are inverted (dark piece on light chip, light piece on dark chip). The material-advantage counter is pinned to the left via `insertWidget(0, …)` so it no longer wanders as new pieces are captured.
- `cffbb61` **fix(gui):** pawns (up to 8) now render as a compact `♟³` chip instead of eight individual labels. This keeps the captured-pieces row narrow so it does not stretch the chess board horizontally and break the square aspect ratio. The superscript count is rendered with Unicode superscript digits (⁰¹²³⁴⁵⁶⁷⁸⁹) instead of HTML `<sup>` — `<sup>` made QLabel reserve a separate box for the digit and push the piece symbol down so it no longer lined up with the other piece chips.

### 2. Evaluation graph (`graph_widget.py`) — pinned height
- `636806a` **fix(gui):** `setFixedHeight(int(self.figure.get_figheight() * self.figure.get_dpi()))` in the constructor, so the graph no longer eats the entire vertical space of the analysis panel.

### 3. Board geometry (`board_widget.py` + `main_window.py`) — square, eval bar, layout
- `ef9e176` **fix(gui):** `_enforce_square_board` computes `side = min(avail_w, avail_h)` and positions the board container + eval bar manually. Foundation: `BoardWidget` is a self-contained component with its own geometry responsibility.
- `fd36032` **fix(gui):** dropped the inner `QHBoxLayout`. The layout was overriding our manual `setGeometry` on `update_board()`, which distorted the board after the first move. The eval bar and board container are now direct children of `BoardWidget`.
- `2921062` **fix(gui):** `EvalBarWidget(self)` → `EvalBarWidget()` + `setParent(self)`. The constructor takes no parent argument; the previous call raised `TypeError` on startup.
- `df2278e` **fix(gui):** without an inner layout, `BoardWidget` was collapsing to its `sizeHint`/minimum. Fixed by `setSizePolicy(Expanding, Expanding)` on the board widget and `setStretch(1, 1)` on the center row in `MainWindow`. `_enforce_square_board` still clamps the actual size to a square inside the available space.

## Why this order?

The commits are ordered chronologically by the smallest committable
diff:

1. First the captured-pieces row (its own widget, no cross-dependencies).
2. Then the graph (standalone, single file).
3. Then the board geometry (four commits, because the root cause was
   diagnosed iteratively — layout conflict, parent constructor, size
   policy).

Every commit is independently runnable, except `2921062` which throws
`TypeError` without `fd36032` — they have to land together.

## Testing

Manually verified on RPi5 (Debian 12, PyQt6 6.4.2, Python 3.11.2):

- The board stays square after every move.
- With 8 captured pawns, the captured-pieces row stays narrow and the
  board is no longer stretched horizontally.
- The eval bar is flush with the board height.
- The eval graph fills its assigned height without squeezing the
  board.
- The material-advantage counter stays pinned to the left even as
  new pieces are captured.

No new unit tests in this bundle (GUI behaviour, hard to test in
isolation). Existing tests still pass.

## Before / after

_(Placeholder for screenshots — please add before merging.)_
# GUI fixes — Sammel-PR

Bundle of eight related bugfixes and improvements around the
analysis-view layout. The commits build on each other cleanly, but
are grouped into three logical themes for easier review.

## Files changed

| File | +/− |
|---|---|
| `src/gui/analysis/captured.py` | +147 / −49 |
| `src/gui/board/board_widget.py` | +57 / −19 |
| `src/gui/main_window.py` | +42 / −8 |
| `src/gui/graph_widget.py` | +5 / 0 |
| **Total** | **+251 / −76** |

## Overview

### 1. Captured-pieces widget (`captured.py`) — refactor, style, compactness
- `ed53eab` **refactor(gui):** widget is split into two per-side instances (one above, one below the board) with a fixed height of `56 px` so the board no longer jumps on the first capture.
- `c9d6a03` **style(gui):** chip backgrounds are inverted (dark piece on light chip, light piece on dark chip). The material-advantage counter is pinned to the left via `insertWidget(0, …)` so it no longer wanders as new pieces are captured.
- `cffbb61` **fix(gui):** pawns (up to 8) now render as a compact `♟³` chip instead of eight individual labels. This keeps the captured-pieces row narrow so it does not stretch the chess board horizontally and break the square aspect ratio. The superscript count is rendered with Unicode superscript digits (⁰¹²³⁴⁵⁶⁷⁸⁹) instead of HTML `<sup>` — `<sup>` made QLabel reserve a separate box for the digit and push the piece symbol down so it no longer lined up with the other piece chips.

### 2. Evaluation graph (`graph_widget.py`) — pinned height
- `636806a` **fix(gui):** `setFixedHeight(int(self.figure.get_figheight() * self.figure.get_dpi()))` in the constructor, so the graph no longer eats the entire vertical space of the analysis panel.

### 3. Board geometry (`board_widget.py` + `main_window.py`) — square, eval bar, layout
- `ef9e176` **fix(gui):** `_enforce_square_board` computes `side = min(avail_w, avail_h)` and positions the board container + eval bar manually. Foundation: `BoardWidget` is a self-contained component with its own geometry responsibility.
- `fd36032` **fix(gui):** dropped the inner `QHBoxLayout`. The layout was overriding our manual `setGeometry` on `update_board()`, which distorted the board after the first move. The eval bar and board container are now direct children of `BoardWidget`.
- `2921062` **fix(gui):** `EvalBarWidget(self)` → `EvalBarWidget()` + `setParent(self)`. The constructor takes no parent argument; the previous call raised `TypeError` on startup.
- `df2278e` **fix(gui):** without an inner layout, `BoardWidget` was collapsing to its `sizeHint`/minimum. Fixed by `setSizePolicy(Expanding, Expanding)` on the board widget and `setStretch(1, 1)` on the center row in `MainWindow`. `_enforce_square_board` still clamps the actual size to a square inside the available space.

## Why this order?

The commits are ordered chronologically by the smallest committable
diff:

1. First the captured-pieces row (its own widget, no cross-dependencies).
2. Then the graph (standalone, single file).
3. Then the board geometry (four commits, because the root cause was
   diagnosed iteratively — layout conflict, parent constructor, size
   policy).

Every commit is independently runnable, except `2921062` which throws
`TypeError` without `fd36032` — they have to land together.

## Testing

Manually verified on RPi5 (Debian 12, PyQt6 6.4.2, Python 3.11.2):

- The board stays square after every move.
- With 8 captured pawns, the captured-pieces row stays narrow and the
  board is no longer stretched horizontally.
- The eval bar is flush with the board height.
- The eval graph fills its assigned height without squeezing the
  board.
- The material-advantage counter stays pinned to the left even as
  new pieces are captured.

No new unit tests in this bundle (GUI behaviour, hard to test in
isolation). Existing tests still pass.

## After

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/81d5146e-2ca6-4e78-8276-4353aa2843dc" />
