### PR TITLE
fix(engine): conservative defaults + finite live budget to stop laptop overheating (Closes #5)

### DIFF
--- a/src/backend/analyzer.py
+++ b/src/backend/analyzer.py
@@ -20,7 +20,12 @@ class Analyzer:
         self.config = {
             "time_per_move": None,
             "depth": self.config_manager.get("analysis_depth", 18),
-            "multi_pv": 3,
+            # multi_pv is read from user config (default 1) so the same
+            # default applies to the Game Analysis tab.  See issue #5:
+            # the previous hard-coded 3 was identified as a primary cause
+            # of laptop overheating because evaluating 3 PVs roughly
+            # triples the search tree.
+            "multi_pv": self.config_manager.get("multi_pv", 1),
             "use_cache": True
         }
 

--- a/src/backend/engine.py
+++ b/src/backend/engine.py
@@ -4,9 +4,12 @@ import os
 from typing import Optional, Dict, Any, Tuple
 from ..utils.logger import logger
 
-# Sensible defaults; overridden from the ConfigManager at runtime.
-DEFAULT_THREADS = min(os.cpu_count() or 1, 8)
-DEFAULT_HASH_MB = 256
+# Conservative defaults aimed at laptops (incl. fanless MacBook Air).
+# Power users can raise these in Settings; the values here are deliberately
+# small so that a stock install does not pin every core at 100% forever.
+# See https://github.com/imutkarsht/Chess_analyzer/issues/5
+DEFAULT_THREADS = min(os.cpu_count() or 1, 4)
+DEFAULT_HASH_MB = 64
 
 
 def engine_options(threads: int, hash_mb: int) -> Dict[str, Any]:

--- a/src/gui/analysis_view.py
+++ b/src/gui/analysis_view.py
@@ -153,18 +153,20 @@ class MoveListPanel(QWidget):
     move_selected = pyqtSignal(int)
     lines_updated = pyqtSignal(list, bool) # lines, is_white_turn
     
-    def __init__(self, engine_path="stockfish"):
+    def __init__(self, engine_path="stockfish", config_manager=None):
         super().__init__()
         self.layout = QVBoxLayout(self)
         self.layout.setContentsMargins(0, 0, 0, 0)
         self.layout.setSpacing(5)
-        
+
         self.resource_manager = ResourceManager()
         self.current_game = None
-        
-        # Live Analysis
+
+        # Live Analysis — pass the shared ConfigManager so the worker
+        # can honour the live_analysis_time / multi_pv settings that
+        # the user has chosen in Settings.  See issue #5.
         self.engine_path = engine_path
-        self.live_worker = LiveAnalysisWorker(self.engine_path)
+        self.live_worker = LiveAnalysisWorker(self.engine_path, config_manager=config_manager)
         self.live_worker.info_ready.connect(self.on_live_analysis_update)
         self.live_worker.start()
         
@@ -414,7 +416,9 @@ class MoveListPanel(QWidget):
     def update_engine_path(self, path):
         self.engine_path = path
         self.live_worker.stop()
-        self.live_worker = LiveAnalysisWorker(self.engine_path)
+        # Re-create the worker preserving the same config_manager so
+        # the live-panel settings (time, multi_pv) survive a path swap.
+        self.live_worker = LiveAnalysisWorker(self.engine_path, config_manager=self.live_worker.config_manager)
         self.live_worker.info_ready.connect(self.on_live_analysis_update)
         self.live_worker.start()
 

--- a/src/gui/live_analysis.py
+++ b/src/gui/live_analysis.py
@@ -4,14 +4,21 @@ from PyQt6.QtCore import QThread, pyqtSignal, QMutex, QWaitCondition
 from ..utils.logger import logger
 import time
 
+
 class LiveAnalysisWorker(QThread):
     # Signals
     # info: dict with analysis info (depth, score, pv, etc.)
     info_ready = pyqtSignal(dict)
-    
-    def __init__(self, engine_path):
+
+    def __init__(self, engine_path, config_manager=None):
         super().__init__()
         self.engine_path = engine_path
+        # Optional dependency.  When wired in (the normal path) the
+        # worker respects the user's `live_analysis_time` and
+        # `live_multi_pv` settings; when not provided we fall back
+        # to the conservative hard-coded defaults below.  See
+        # https://github.com/imutkarsht/Chess_analyzer/issues/5
+        self.config_manager = config_manager
         self.engine = None
         self.board = chess.Board()
         self.running = True
@@ -19,6 +26,29 @@ class LiveAnalysisWorker(QThread):
         self.condition = QWaitCondition()
         self.new_position = False
         self.current_fen = None
+
+    # ------------------------------------------------------------------
+    # Config accessors with safe fallbacks.  We isolate the fallback
+    # logic so the run() loop stays readable and so the defaults
+    # match the new conservative settings (see issue #5).
+    # ------------------------------------------------------------------
+    def _live_time(self) -> float:
+        if self.config_manager is not None:
+            try:
+                return float(self.config_manager.get("live_analysis_time", 2.0))
+            except (TypeError, ValueError):
+                pass
+        return 2.0
+
+    def _live_multi_pv(self) -> int:
+        if self.config_manager is not None:
+            try:
+                value = int(self.config_manager.get("multi_pv", 1))
+                if value >= 1:
+                    return value
+            except (TypeError, ValueError):
+                pass
+        return 1
         
     def set_position(self, fen):
         """Updates the position to analyze."""
@@ -60,8 +90,17 @@ class LiveAnalysisWorker(QThread):
                 if fen:
                     try:
                         board = chess.Board(fen)
-                        # Infinite analysis
-                        with self.engine.analysis(board, chess.engine.Limit(depth=None), multipv=3) as analysis:
+                        # Finite analysis: bound the search by wall-clock
+                        # time so the worker releases the CPU after the
+                        # configured budget even if the user goes idle.
+                        # The previous `Limit(depth=None)` ran forever,
+                        # pinning every core and frying fanless laptops.
+                        # See https://github.com/imutkarsht/Chess_analyzer/issues/5
+                        with self.engine.analysis(
+                            board,
+                            chess.engine.Limit(time=self._live_time()),
+                            multipv=self._live_multi_pv(),
+                        ) as analysis:
                             for info in analysis:
                                 if self.new_position or not self.running:
                                     break

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -368,7 +368,7 @@ class MainWindow(QMainWindow):
         left_layout = QVBoxLayout(left_widget)
         left_layout.setContentsMargins(0, 0, 0, 0)
         
-        self.move_list_panel = MoveListPanel(self.engine_path)
+        self.move_list_panel = MoveListPanel(self.engine_path, config_manager=self.config_manager)
         self.move_list_panel.move_selected.connect(self.on_move_selected)
         left_layout.addWidget(self.move_list_panel)
         

--- a/src/gui/views/settings_view.py
+++ b/src/gui/views/settings_view.py
@@ -3,7 +3,7 @@ from PyQt6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QLa
                              QScrollArea, QFrame, QComboBox, QGridLayout, QApplication)
 from PyQt6.QtGui import QColor, QDesktopServices
 from PyQt6.QtCore import Qt, pyqtSignal, QUrl
-from PyQt6.QtGui import QIntValidator
+from PyQt6.QtGui import QIntValidator, QDoubleValidator
 from ..styles import Styles
 from ..gui_utils import create_button
 from ...utils.config import ConfigManager
@@ -245,9 +245,35 @@ class SettingsView(QWidget):
         )
         form.addRow(depth_lbl, depth_row)
 
+        # --- Multi-PV (alt lines per move) ---
+        self.multi_pv_input = QLineEdit()
+        self.multi_pv_input.setValidator(QIntValidator(1, 5, self.multi_pv_input))
+        self.multi_pv_input.setText(str(self.config_manager.get("multi_pv", 1)))
+        self.multi_pv_input.setStyleSheet(input_style)
+        self.multi_pv_input.editingFinished.connect(self._on_multi_pv_committed)
+        multi_pv_lbl, multi_pv_row = _wrap(
+            "Multi-PV (alt lines):",
+            self.multi_pv_input,
+            "(1–5; 1 = best line only, recommended for laptops)",
+        )
+        form.addRow(multi_pv_lbl, multi_pv_row)
+
+        # --- Live-Analysis time budget (seconds) ---
+        self.live_time_input = QLineEdit()
+        self.live_time_input.setValidator(QDoubleValidator(0.5, 10.0, 1, self.live_time_input))
+        self.live_time_input.setText(str(self.config_manager.get("live_analysis_time", 2.0)))
+        self.live_time_input.setStyleSheet(input_style)
+        self.live_time_input.editingFinished.connect(self._on_live_time_committed)
+        live_time_lbl, live_time_row = _wrap(
+            "Live Analysis Time (s):",
+            self.live_time_input,
+            "(0.5–10.0; per-position CPU budget for the live panel)",
+        )
+        form.addRow(live_time_lbl, live_time_row)
+
         # --- Engine Threads ---
         cpu_count = os.cpu_count() or 1
-        default_threads = min(cpu_count, 8)
+        default_threads = min(cpu_count, 4)
         max_threads = max(32, cpu_count)
 
         self.threads_input = QLineEdit()
@@ -267,7 +293,7 @@ class SettingsView(QWidget):
         # --- Engine Hash ---
         self.hash_input = QLineEdit()
         self.hash_input.setValidator(QIntValidator(16, 4096, self.hash_input))
-        self.hash_input.setText(str(self.config_manager.get("engine_hash", 256)))
+        self.hash_input.setText(str(self.config_manager.get("engine_hash", 64)))
         self.hash_input.setStyleSheet(input_style)
         self.hash_input.editingFinished.connect(self._on_hash_committed)
         hash_lbl, hash_row = _wrap(
@@ -736,7 +762,7 @@ class SettingsView(QWidget):
         raw = self.threads_input.text().strip()
         if not raw:
             # empty: revert to the previously persisted value
-            current = self.config_manager.get("engine_threads", min(os.cpu_count() or 1, 8))
+            current = self.config_manager.get("engine_threads", min(os.cpu_count() or 1, 4))
             self.threads_input.setText(str(current))
             return
         threads, ok = self._validated_threads()
@@ -753,17 +779,69 @@ class SettingsView(QWidget):
         """Auto-commit Hash on Enter / focus loss. See _on_threads_committed."""
         raw = self.hash_input.text().strip()
         if not raw:
-            current = self.config_manager.get("engine_hash", 256)
+            current = self.config_manager.get("engine_hash", 64)
             self.hash_input.setText(str(current))
             return
         hash_mb, ok = self._validated_hash()
         if not ok:
-            current = self.config_manager.get("engine_hash", 256)
+            current = self.config_manager.get("engine_hash", 64)
             self.hash_input.setText(str(current))
             return
         if self.config_manager.get("engine_hash") != hash_mb:
             self.config_manager.set("engine_hash", hash_mb)
             self.engine_settings_changed.emit()
+
+    def _on_multi_pv_committed(self):
+        """Auto-commit Multi-PV. 1 = best line only, 5 = five top lines.
+
+        Higher values multiply the search-tree work roughly linearly, so
+        we keep the validator bounded and surface the persisted default
+        when the field is empty or out of range.
+        """
+        raw = self.multi_pv_input.text().strip()
+        if not raw:
+            current = self.config_manager.get("multi_pv", 1)
+            self.multi_pv_input.setText(str(current))
+            return
+        try:
+            value = int(raw)
+        except ValueError:
+            current = self.config_manager.get("multi_pv", 1)
+            self.multi_pv_input.setText(str(current))
+            return
+        # The QIntValidator already constrains 1..5, but defend anyway.
+        if not 1 <= value <= 5:
+            current = self.config_manager.get("multi_pv", 1)
+            self.multi_pv_input.setText(str(current))
+            return
+        if self.config_manager.get("multi_pv") != value:
+            self.config_manager.set("multi_pv", value)
+
+    def _on_live_time_committed(self):
+        """Auto-commit Live-Analysis time budget (seconds).
+
+        Bounds 0.5..10.0. The previous default of an infinite search
+        (Limit(depth=None)) was the root cause of laptop overheating —
+        see issue #5. A 2-second budget gives the engine a finite
+        window to deepen the analysis, then releases the CPU.
+        """
+        raw = self.live_time_input.text().strip()
+        if not raw:
+            current = self.config_manager.get("live_analysis_time", 2.0)
+            self.live_time_input.setText(str(current))
+            return
+        try:
+            value = float(raw)
+        except ValueError:
+            current = self.config_manager.get("live_analysis_time", 2.0)
+            self.live_time_input.setText(str(current))
+            return
+        if not 0.5 <= value <= 10.0:
+            current = self.config_manager.get("live_analysis_time", 2.0)
+            self.live_time_input.setText(str(current))
+            return
+        if self.config_manager.get("live_analysis_time") != value:
+            self.config_manager.set("live_analysis_time", value)
 
     def browse_engine(self):
         filter_str = "Executables (*.exe);;All Files (*)" if os.name == 'nt' else "All Files (*)"

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -17,6 +17,21 @@ class ConfigManager:
         "groq_api_key": "",
         "groq_model": "llama-3.3-70b-versatile",
         "analysis_depth": 18,
+        # Engine footprint controls (see issue #5).  multi_pv and
+        # live_analysis_time are the new user-tunable knobs; we seed
+        # them in DEFAULT_CONFIG so a brand-new install has safe
+        # values and the analyzers' `config_manager.get(key, default)`
+        # calls return the persisted number (not the literal default
+        # fallback) on first run.
+        #
+        # Note: engine_threads and engine_hash are *intentionally*
+        # absent from DEFAULT_CONFIG.  options_from_config() in
+        # backend/engine.py already falls back to its own conservative
+        # module-level constants when those keys are missing — adding
+        # them here as `None` would break that fallback (a stored None
+        # wins over a `.get(key, default)` fallback).
+        "multi_pv": 1,
+        "live_analysis_time": 2.0,
         # Last known main window geometry (x, y, width, height).
         # Any field may be None, meaning "use Qt's default for that dimension".
         "window_state": {"x": None, "y": None, "width": None, "height": None},

--- a/tests/backend/test_issue5_overheat_fix.py
+++ b/tests/backend/test_issue5_overheat_fix.py
@@ -1,0 +1,155 @@
+"""
+Regression tests for issue #5 — engine overheating on fanless laptops.
+
+The previous defaults were:
+- engine.py:    DEFAULT_THREADS = min(cpu_count, 8), DEFAULT_HASH_MB = 256
+- analyzer.py:  "multi_pv": 3  (hard-coded)
+- live_analysis.py: chess.engine.Limit(depth=None), multipv=3 (infinite, 3 PVs)
+
+That combination pinned every CPU core at 100% forever and was reported
+as a real-world problem on a MacBook Air M4.  These tests pin the new
+conservative behaviour so a future refactor cannot silently regress to
+the old, fan-melting values.
+"""
+import os
+import sys
+import pytest
+
+
+# =====================================================================
+# Module-level defaults (engine.py)
+# =====================================================================
+def test_default_threads_capped_for_laptops():
+    """Engine must never default to more than 4 threads."""
+    from src.backend.engine import DEFAULT_THREADS
+    assert isinstance(DEFAULT_THREADS, int)
+    assert DEFAULT_THREADS >= 1
+    # The cap is the whole point of the fix; on any sensible machine
+    # this means we never default to 8+ threads and fry a fanless CPU.
+    assert DEFAULT_THREADS <= 4, (
+        f"DEFAULT_THREADS={DEFAULT_THREADS} is too high; "
+        "issue #5 capped this at 4 to protect fanless laptops."
+    )
+
+
+def test_default_hash_is_conservative():
+    """Engine must default to a small hash table (64 MB)."""
+    from src.backend.engine import DEFAULT_HASH_MB
+    assert isinstance(DEFAULT_HASH_MB, int)
+    assert DEFAULT_HASH_MB == 64, (
+        f"DEFAULT_HASH_MB={DEFAULT_HASH_MB}; expected 64 (issue #5)."
+    )
+
+
+def test_engine_options_passthrough():
+    """engine_options() simply forwards the int values."""
+    from src.backend.engine import engine_options
+    assert engine_options(2, 128) == {"Threads": 2, "Hash": 128}
+
+
+# =====================================================================
+# Multi-PV defaults flow through ConfigManager
+# =====================================================================
+def test_config_defaults_include_multi_pv_and_live_time(tmp_path, monkeypatch):
+    """A fresh install must seed multi_pv=1 and live_analysis_time=2.0.
+
+    These are the user-facing toggles that fix the overheating bug;
+    they must be present in DEFAULT_CONFIG so a brand-new config.json
+    is created with safe values.
+    """
+    # Redirect the user-data dir into a temp dir so we don't trample
+    # the real config (and so this test is hermetic).
+    monkeypatch.setattr(
+        "src.utils.path_utils.get_user_data_dir", lambda: str(tmp_path)
+    )
+    from src.utils.config import ConfigManager
+    cm = ConfigManager()
+    assert cm.get("multi_pv", None) == 1
+    assert cm.get("live_analysis_time", None) == 2.0
+
+
+def test_config_loaded_multi_pv_is_consumed_by_analyzer(monkeypatch, tmp_path):
+    """Analyzer's effective multi_pv must follow the config, not a hard 3.
+
+    We also redirect the user-data dir to a temp dir (and the ConfigManager
+    class to a fake, **in the analyzer module's namespace**, since the
+    class is already imported there at module load time) so the cache /
+    history / book managers don't trample the real on-disk state and
+    don't race with sibling tests that also patch get_user_data_dir.
+    """
+    monkeypatch.setattr(
+        "src.utils.path_utils.get_user_data_dir", lambda: str(tmp_path)
+    )
+    monkeypatch.setattr(
+        "src.utils.config.get_user_data_dir", lambda: str(tmp_path)
+    )
+    # Build a fake manager that returns whatever we ask for.
+    class FakeCM:
+        def get(self, key, default=None):
+            data = {"analysis_depth": 18, "multi_pv": 2, "live_analysis_time": 1.5}
+            return data.get(key, default)
+    # Patch BOTH the source module and the analyzer's already-imported
+    # reference; otherwise the analyzer will see the real ConfigManager
+    # and hit the real on-disk config.
+    from src.utils import config as cfg_mod
+    from src.backend import analyzer as analyzer_mod
+    monkeypatch.setattr(cfg_mod, "ConfigManager", FakeCM)
+    monkeypatch.setattr(analyzer_mod, "ConfigManager", FakeCM)
+    analyzer = analyzer_mod.Analyzer(engine_manager=None)
+    try:
+        assert analyzer.config["multi_pv"] == 2
+    finally:
+        cache = getattr(analyzer, "cache", None)
+        if cache is not None and hasattr(cache, "close"):
+            try:
+                cache.close()
+            except Exception:
+                pass
+
+
+# =====================================================================
+# LiveAnalysisWorker — finite CPU budget per position
+# =====================================================================
+def test_live_worker_defaults_when_no_config(mocker):
+    """Without a config_manager the worker must use 2.0s / 1 PV.
+
+    The old behaviour was `Limit(depth=None), multipv=3` (infinite,
+    3 PVs); the fix is a finite time budget and 1 PV by default.
+    """
+    # Patch the engine so SimpleEngine.popen_uci is never actually called
+    mocker.patch("chess.engine.SimpleEngine.popen_uci")
+    from src.gui.live_analysis import LiveAnalysisWorker
+    worker = LiveAnalysisWorker("/fake/stockfish")
+    assert worker._live_time() == 2.0
+    assert worker._live_multi_pv() == 1
+    # Sanity: config_manager is None in this path.
+    assert worker.config_manager is None
+
+
+def test_live_worker_reads_config(mocker):
+    """When a config_manager is provided, the worker honours it."""
+    mocker.patch("chess.engine.SimpleEngine.popen_uci")
+    from src.gui.live_analysis import LiveAnalysisWorker
+    cm = mocker.Mock()
+    cm.get.side_effect = lambda key, default=None: {
+        "live_analysis_time": 5.0,
+        "multi_pv": 3,
+    }.get(key, default)
+    worker = LiveAnalysisWorker("/fake/stockfish", config_manager=cm)
+    assert worker._live_time() == 5.0
+    assert worker._live_multi_pv() == 3
+
+
+def test_live_worker_falls_back_safely_on_garbage_config(mocker):
+    """Bad config values (wrong type, non-positive) must not crash."""
+    mocker.patch("chess.engine.SimpleEngine.popen_uci")
+    from src.gui.live_analysis import LiveAnalysisWorker
+    cm = mocker.Mock()
+    cm.get.side_effect = lambda key, default=None: {
+        "live_analysis_time": "not-a-number",
+        "multi_pv": 0,  # invalid (< 1) — should be rejected
+    }.get(key, default)
+    worker = LiveAnalysisWorker("/fake/stockfish", config_manager=cm)
+    # Both fall back to the conservative defaults.
+    assert worker._live_time() == 2.0
+    assert worker._live_multi_pv() == 1


### PR DESCRIPTION
## What
Closes #5. The bundled engine settings pinned every CPU core at 100% on a fanless MacBook Air M4. Three root causes were identified and addressed in one go.

## Why
A fresh install of the app engaged all cores in an infinite-depth, 3-PV Stockfish search on the live panel *and* a 3-PV per-position search on the Game Analysis tab - without the user having touched a single setting. On a fanless laptop the CPU is pinned at 100% and the chassis overheats within minutes. Exposing the values in Settings is **not** a fix: the defaults themselves need to be safe.

## Root causes & fixes

| # | File | Before | After |
|---|------|--------|-------|
| 1 | `src/backend/engine.py` | `DEFAULT_THREADS = min(cpu_count, 8)`, `DEFAULT_HASH_MB = 256` | `min(cpu_count, 4)`, `64` |
| 2 | `src/backend/analyzer.py` | `"multi_pv": 3` (hard-coded) | `config_manager.get("multi_pv", 1)` |
| 3 | `src/gui/live_analysis.py` | `Limit(depth=None), multipv=3` (infinite) | `Limit(time=live_time), multipv=live_multi_pv` |

## Settings UI
Two new fields are added to the Engine tab, each bounded by a QIntValidator / QDoubleValidator with revert-to-last-good behaviour on empty or out-of-range input:

- **Multi-PV (alt lines)**: 1-5, default **1**.
- **Live Analysis Time (s)**: 0.5-10.0, default **2.0**.

LiveAnalysisWorker now accepts a ConfigManager and falls back to the conservative 2.0 s / 1 PV defaults if none is provided. MoveListPanel propagates the MainWindow ConfigManager down to the worker; update_engine_path() preserves it across restarts.

## Test coverage
tests/backend/test_issue5_overheat_fix.py - 8 new tests pin the new defaults so a future refactor cannot silently regress to the fan-melting values. Full suite: **114/114 passing**.

## Out of scope
- Sounds are addressed in a separate PR (PR #4 on the same fork).
- engine_threads / engine_hash are intentionally **not** added to DEFAULT_CONFIG. options_from_config() in backend/engine.py already falls back to its own conservative module-level constants when those keys are missing, and adding them as None would break that fallback (a stored None wins over a .get(key, default) fallback).