### PR TITLE
feat: auto-detect Stockfish binary (resolve via PATH, common paths, d…

### DIFF
--- a/src/backend/analysis/analyzer.py
+++ b/src/backend/analysis/analyzer.py
@@ -293,7 +293,11 @@ class Analyzer:
         
         if board.is_game_over():
             if board.is_checkmate():
-                return chess.engine.PovScore(chess.engine.Mate(0), board.turn)
+                # Mate(-1) from the mated side's perspective: "the opponent
+                # can deliver mate." This unambiguously encodes the winner
+                # after downstream normalization (unlike Mate(0) which loses
+                # polarity when -0 = 0).
+                return chess.engine.PovScore(chess.engine.Mate(-1), board.turn)
             else:
                 return chess.engine.PovScore(chess.engine.Cp(0), board.turn)
                 

--- a/src/backend/analysis/engine.py
+++ b/src/backend/analysis/engine.py
@@ -1,8 +1,11 @@
 import chess.engine
 import chess
 import os
-from typing import Optional, Dict, Any, Tuple
+import sys
+import shutil
+from typing import Optional, Dict, Any, Tuple, List
 from src.utils.logger import logger
+from src.utils.path_utils import get_stockfish_common_paths, get_engine_data_dir
 
 # Conservative defaults aimed at laptops (incl. fanless MacBook Air).
 # Power users can raise these in Settings; the values here are deliberately
@@ -32,6 +35,63 @@ def options_from_config(config_manager=None) -> Dict[str, Any]:
     threads = config_manager.get("engine_threads", DEFAULT_THREADS)
     hash_mb = config_manager.get("engine_hash", DEFAULT_HASH_MB)
     return engine_options(threads, hash_mb)
+
+
+def _validate_engine_path(path: str) -> bool:
+    """Check whether *path* exists and looks like a UCI engine binary.
+
+    Uses ``os.path.isfile`` and an execute-bit check (non-Windows) to
+    weed-out obvious mismatches without launching a subprocess.
+    """
+    if not path or not os.path.isfile(path):
+        return False
+    if sys.platform != "win32" and not os.access(path, os.X_OK):
+        return False
+    return True
+
+
+def resolve_engine_path(config_manager=None) -> Optional[str]:
+    """Auto-detect a Stockfish binary using the priority table.
+
+    | Priority | Check |
+    |----------|-------|
+    | 1        | ``config["engine_path"]`` – explicit user setting |
+    | 2        | ``shutil.which("stockfish")`` – ``$PATH`` (Homebrew, system) |
+    | 3        | Platform-specific common paths |
+    | 4        | Already-downloaded in engine data dir |
+    | 5        | ``None`` – caller should fall back to download |
+
+    Returns the path string or ``None`` if nothing was found.
+    """
+    # Priority 1 – explicit user setting
+    if config_manager is not None:
+        cfg_path = config_manager.get("engine_path", "")
+        if cfg_path:
+            resolved = shutil.which(cfg_path) or cfg_path
+            if _validate_engine_path(resolved):
+                logger.info("resolve_engine_path: using config path %s", resolved)
+                return resolved
+
+    # Priority 2 – PATH lookup
+    which_path = shutil.which("stockfish")
+    if which_path and _validate_engine_path(which_path):
+        logger.info("resolve_engine_path: found via PATH at %s", which_path)
+        return which_path
+
+    # Priority 3 – platform-specific common paths
+    for candidate in get_stockfish_common_paths():
+        if _validate_engine_path(candidate):
+            logger.info("resolve_engine_path: found at common path %s", candidate)
+            return candidate
+
+    # Priority 4 – previously downloaded
+    downloaded = os.path.join(get_engine_data_dir(), "stockfish")
+    if _validate_engine_path(downloaded):
+        logger.info("resolve_engine_path: found previously downloaded at %s", downloaded)
+        return downloaded
+
+    logger.info("resolve_engine_path: no Stockfish found, returning None")
+    return None
 
 
 class EngineManager:
@@ -111,6 +171,30 @@ class EngineManager:
             threads=self.config_manager.get("engine_threads", DEFAULT_THREADS),
             hash_mb=self.config_manager.get("engine_hash", DEFAULT_HASH_MB),
         )
+
+    def recheck_engine_path(self, config_manager=None) -> bool:
+        """Re-run auto-detection and restart the engine if the path changed.
+
+        This is useful after the user downloads Stockfish through the setup
+        wizard or changes settings – call it to pick up the new binary
+        without requiring an app restart.
+
+        Returns ``True`` if the engine is running (or was successfully
+        restarted) after the check.
+        """
+        new_path = resolve_engine_path(config_manager)
+        if new_path is None:
+            return False
+        if new_path != self.engine_path:
+            self.stop_engine()
+            self.engine_path = new_path
+        if self.engine is None:
+            try:
+                self.start_engine()
+            except Exception:
+                logger.exception("recheck_engine_path: failed to start engine at %s", new_path)
+                return False
+        return self.engine is not None
 
     def analyze_position(self, board: chess.Board, time_limit: float = 0.1, depth: Optional[int] = None, multi_pv: int = 1) -> chess.engine.InfoDict:
         if not self.engine:

--- a/src/backend/engine/downloader.py
+++ b/src/backend/engine/downloader.py
@@ -1,0 +1,168 @@
+import sys
+import os
+import tarfile
+import zipfile
+import tempfile
+import shutil
+import stat
+from typing import Optional, Callable
+from dataclasses import dataclass
+
+import requests
+
+
+GITHUB_API = "https://api.github.com/repos/official-stockfish/Stockfish/releases/latest"
+
+PLATFORM_ASSETS: dict[tuple[str, str], str] = {
+    ("darwin", "arm64"):  "stockfish-macos-universal.tar.gz",
+    ("darwin", "x86_64"): "stockfish-macos-universal.tar.gz",
+    ("win32",  "x86_64"): "stockfish-windows-x86-64-universal.zip",
+    ("linux",  "x86_64"): "stockfish-linux-x86-64-universal.tar.gz",
+}
+
+
+@dataclass
+class ReleaseAsset:
+    name: str
+    url: str
+    size: int
+
+
+def get_current_platform() -> tuple[str, str]:
+    """Return (system, machine) tuple suitable for PLATFORM_ASSETS lookup."""
+    system_map = {"darwin": "darwin", "win32": "win32", "linux": "linux"}
+    system = system_map.get(sys.platform)
+    if system is None:
+        raise RuntimeError(f"Unsupported platform: {sys.platform}")
+    machine = "x86_64"
+    if system == "darwin" and sys.platform == "darwin":
+        import platform
+        machine = platform.machine()
+        if machine == "arm64":
+            machine = "arm64"
+        else:
+            machine = "x86_64"
+    elif system == "linux":
+        import platform
+        machine = platform.machine()
+    return system, machine
+
+
+def get_expected_asset_name() -> str:
+    """Return the expected Stockfish release asset name for the current platform."""
+    platform_key = get_current_platform()
+    asset_name = PLATFORM_ASSETS.get(platform_key)
+    if asset_name is None:
+        raise RuntimeError(
+            f"No Stockfish asset defined for platform {platform_key}. "
+            f"Supported: {list(PLATFORM_ASSETS.keys())}"
+        )
+    return asset_name
+
+
+def get_official_releases() -> list[ReleaseAsset]:
+    """Fetch the latest Stockfish release from GitHub and return its assets."""
+    resp = requests.get(GITHUB_API, timeout=15)
+    resp.raise_for_status()
+    data = resp.json()
+    assets = []
+    for asset in data.get("assets", []):
+        assets.append(ReleaseAsset(
+            name=asset["name"],
+            url=asset["browser_download_url"],
+            size=asset["size"],
+        ))
+    return assets
+
+
+def get_download_url(releases: list[ReleaseAsset], target_asset: str) -> Optional[str]:
+    """Find the download URL for the given asset name in the release list."""
+    for asset in releases:
+        if asset.name == target_asset:
+            return asset.url
+    return None
+
+
+def download_and_extract(
+    url: str,
+    dest_dir: str,
+    progress_callback: Optional[Callable[[int, int], None]] = None,
+) -> str:
+    """Download a Stockfish archive and extract the binary.
+
+    Args:
+        url: Direct download URL for the archive.
+        dest_dir: Directory to extract into.
+        progress_callback: Optional callback(bytes_downloaded, total_bytes).
+
+    Returns:
+        Absolute path to the extracted Stockfish binary.
+    """
+    os.makedirs(dest_dir, exist_ok=True)
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".download") as tmp:
+        tmp_path = tmp.name
+
+    try:
+        resp = requests.get(url, stream=True, timeout=30)
+        resp.raise_for_status()
+
+        total = int(resp.headers.get("content-length", 0))
+        downloaded = 0
+
+        with open(tmp_path, "wb") as f:
+            for chunk in resp.iter_content(chunk_size=8192):
+                if chunk:
+                    f.write(chunk)
+                    downloaded += len(chunk)
+                    if progress_callback and total:
+                        progress_callback(downloaded, total)
+
+        if url.endswith(".zip"):
+            return _extract_zip(tmp_path, dest_dir)
+        else:
+            return _extract_tar(tmp_path, dest_dir)
+
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+def _extract_zip(archive_path: str, dest_dir: str) -> str:
+    """Extract a .zip archive and return the path to the Stockfish binary."""
+    with zipfile.ZipFile(archive_path, "r") as zf:
+        zf.extractall(dest_dir)
+
+    return _find_binary(dest_dir)
+
+
+def _extract_tar(archive_path: str, dest_dir: str) -> str:
+    """Extract a .tar.gz archive and return the path to the Stockfish binary."""
+    with tarfile.open(archive_path, "r:gz") as tf:
+        tf.extractall(dest_dir)
+
+    return _find_binary(dest_dir)
+
+
+def _find_binary(search_dir: str) -> str:
+    """Find the Stockfish binary inside an extracted directory.
+
+    Searches recursively for a file named 'stockfish' (or 'stockfish.exe' on Windows).
+    """
+    target = "stockfish.exe" if sys.platform == "win32" else "stockfish"
+    for root, _dirs, files in os.walk(search_dir):
+        for f in files:
+            if f == target:
+                path = os.path.join(root, f)
+                _make_executable(path)
+                return path
+    raise FileNotFoundError(
+        f"Could not find '{target}' in extracted contents under {search_dir}"
+    )
+
+
+def _make_executable(path: str) -> None:
+    """Ensure the binary is executable (no-op on Windows)."""
+    if sys.platform != "win32":
+        st = os.stat(path)
+        os.chmod(path, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)

--- a/src/gui/analysis/analysis_panel.py
+++ b/src/gui/analysis/analysis_panel.py
@@ -98,6 +98,7 @@ class AnalysisPanel(QWidget):
         self.opening_label = QLabel("Opening: -")
         self.opening_label.setStyleSheet(f"color: {Styles.COLOR_TEXT_SECONDARY}; font-size: 14px; font-weight: bold;")
         self.opening_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.opening_label.setWordWrap(True)
         self.report_layout.addWidget(self.opening_label)
         
         # Accuracy

--- a/src/utils/path_utils.py
+++ b/src/utils/path_utils.py
@@ -63,3 +63,39 @@ def get_user_data_dir() -> str:
     os.makedirs(base_dir, exist_ok=True)
     return base_dir
 
+
+def get_stockfish_common_paths() -> list[str]:
+    """Return a list of common Stockfish binary paths for the current platform.
+
+    These are checked during auto-detection before falling back to download.
+    Order matters — more specific/likely paths come first.
+    """
+    if sys.platform == "darwin":
+        return [
+            "/opt/homebrew/bin/stockfish",     # Apple Silicon Homebrew
+            "/usr/local/bin/stockfish",         # Intel Homebrew / manual
+            "/opt/homebrew/bin/stockfish.exe",  # Wine cross-build (rare)
+        ]
+    elif sys.platform == "win32":
+        return [
+            "C:\\Program Files\\Stockfish\\stockfish.exe",
+            "C:\\Program Files (x86)\\Stockfish\\stockfish.exe",
+            os.path.expanduser("~\\AppData\\Local\\Stockfish\\stockfish.exe"),
+        ]
+    else:
+        return [
+            "/usr/bin/stockfish",
+            "/usr/local/bin/stockfish",
+            "/usr/games/stockfish",
+        ]
+
+
+def get_engine_data_dir() -> str:
+    """Return the platform-specific directory for engine binaries.
+
+    Returns a subdirectory of get_user_data_dir() named 'engine'.
+    """
+    engine_dir = os.path.join(get_user_data_dir(), "engine")
+    os.makedirs(engine_dir, exist_ok=True)
+    return engine_dir
+

--- a/tests/backend/test_downloader.py
+++ b/tests/backend/test_downloader.py
@@ -1,0 +1,195 @@
+import sys
+import os
+import tarfile
+import zipfile
+import tempfile
+import pytest
+from unittest.mock import MagicMock, patch
+
+from src.backend.engine.downloader import (
+    get_current_platform,
+    get_expected_asset_name,
+    get_official_releases,
+    get_download_url,
+    download_and_extract,
+    ReleaseAsset,
+    PLATFORM_ASSETS,
+)
+
+
+class TestGetCurrentPlatform:
+    def test_darwin_arm64(self, mocker):
+        mocker.patch.object(sys, "platform", "darwin")
+        mocker.patch("platform.machine", return_value="arm64")
+        assert get_current_platform() == ("darwin", "arm64")
+
+    def test_darwin_x86_64(self, mocker):
+        mocker.patch.object(sys, "platform", "darwin")
+        mocker.patch("platform.machine", return_value="x86_64")
+        assert get_current_platform() == ("darwin", "x86_64")
+
+    def test_win32(self, mocker):
+        mocker.patch.object(sys, "platform", "win32")
+        assert get_current_platform() == ("win32", "x86_64")
+
+    def test_linux(self, mocker):
+        mocker.patch.object(sys, "platform", "linux")
+        mocker.patch("platform.machine", return_value="x86_64")
+        assert get_current_platform() == ("linux", "x86_64")
+
+    def test_unsupported_platform_raises(self, mocker):
+        mocker.patch.object(sys, "platform", "cygwin")
+        with pytest.raises(RuntimeError, match="Unsupported platform"):
+            get_current_platform()
+
+
+class TestGetExpectedAssetName:
+    def test_macos_universal(self, mocker):
+        mocker.patch.object(sys, "platform", "darwin")
+        mocker.patch("platform.machine", return_value="arm64")
+        assert get_expected_asset_name() == "stockfish-macos-universal.tar.gz"
+
+    def test_windows_universal(self, mocker):
+        mocker.patch.object(sys, "platform", "win32")
+        assert get_expected_asset_name() == "stockfish-windows-x86-64-universal.zip"
+
+    def test_linux_universal(self, mocker):
+        mocker.patch.object(sys, "platform", "linux")
+        mocker.patch("platform.machine", return_value="x86_64")
+        assert get_expected_asset_name() == "stockfish-linux-x86-64-universal.tar.gz"
+
+
+class TestGetOfficialReleases:
+    def test_returns_list_of_assets(self, mocker):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "assets": [
+                {"name": "stockfish-macos-universal.tar.gz",
+                 "browser_download_url": "https://example.com/a.tar.gz",
+                 "size": 12345},
+            ]
+        }
+        mocker.patch("requests.get", return_value=mock_resp)
+
+        assets = get_official_releases()
+        assert len(assets) == 1
+        assert assets[0].name == "stockfish-macos-universal.tar.gz"
+        assert assets[0].url == "https://example.com/a.tar.gz"
+        assert assets[0].size == 12345
+
+    def test_raises_on_http_error(self, mocker):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = Exception("HTTP 404")
+        mocker.patch("requests.get", return_value=mock_resp)
+
+        with pytest.raises(Exception, match="HTTP 404"):
+            get_official_releases()
+
+
+class TestGetDownloadUrl:
+    def test_finds_matching_asset(self):
+        releases = [
+            ReleaseAsset("a.tar.gz", "https://example.com/a.tar.gz", 100),
+            ReleaseAsset("b.zip", "https://example.com/b.zip", 200),
+        ]
+        url = get_download_url(releases, "b.zip")
+        assert url == "https://example.com/b.zip"
+
+    def test_returns_none_when_not_found(self):
+        releases = [ReleaseAsset("a.tar.gz", "https://example.com/a.tar.gz", 100)]
+        url = get_download_url(releases, "nonexistent.zip")
+        assert url is None
+
+
+class TestDownloadAndExtract:
+    def create_tar_fixture(self, tmp_path, binary_name="stockfish"):
+        """Create a .tar.gz with a Stockfish binary inside and return its path."""
+        archive = tmp_path / "test.tar.gz"
+        inner_dir = tmp_path / "stockfish_dir"
+        inner_dir.mkdir()
+        binary = inner_dir / binary_name
+        binary.write_text("fake stockfish binary")
+        binary.chmod(0o755)
+
+        with tarfile.open(str(archive), "w:gz") as tf:
+            tf.add(str(inner_dir), arcname="stockfish_dir")
+
+        return str(archive), str(binary)
+
+    def create_zip_fixture(self, tmp_path, binary_name="stockfish.exe"):
+        """Create a .zip with a Stockfish binary inside and return its path."""
+        archive = tmp_path / "test.zip"
+        inner_dir = tmp_path / "stockfish_dir"
+        inner_dir.mkdir()
+        binary = inner_dir / binary_name
+        binary.write_text("fake stockfish binary")
+
+        with zipfile.ZipFile(str(archive), "w") as zf:
+            zf.write(str(binary), arcname=f"stockfish_dir/{binary_name}")
+
+        return str(archive), str(binary)
+
+    def test_download_and_extract_tar_gz(self, mocker, tmp_path):
+        archive_path, expected_binary = self.create_tar_fixture(tmp_path)
+
+        mock_resp = MagicMock()
+        mock_resp.headers = {"content-length": "1000"}
+        mock_resp.iter_content.return_value = [
+            open(archive_path, "rb").read()
+        ]
+
+        mocker.patch("requests.get", return_value=mock_resp)
+        dest = str(tmp_path / "dest")
+        result = download_and_extract("https://example.com/test.tar.gz", dest)
+
+        assert os.path.isfile(result)
+        assert result.endswith("stockfish")
+        assert os.access(result, os.X_OK)
+
+    def test_download_and_extract_zip(self, mocker, tmp_path):
+        archive_path, expected_binary = self.create_zip_fixture(tmp_path)
+
+        mock_resp = MagicMock()
+        mock_resp.headers = {"content-length": "1000"}
+        mock_resp.iter_content.return_value = [
+            open(archive_path, "rb").read()
+        ]
+
+        mocker.patch("requests.get", return_value=mock_resp)
+        mocker.patch.object(sys, "platform", "win32")
+        dest = str(tmp_path / "dest")
+        result = download_and_extract("https://example.com/test.zip", dest)
+
+        assert os.path.isfile(result)
+        assert result.endswith("stockfish.exe")
+
+    def test_progress_callback_called(self, mocker, tmp_path):
+        archive_path, _ = self.create_tar_fixture(tmp_path)
+
+        mock_resp = MagicMock()
+        mock_resp.headers = {"content-length": str(os.path.getsize(archive_path))}
+        mock_resp.iter_content.return_value = [
+            open(archive_path, "rb").read()
+        ]
+
+        mocker.patch("requests.get", return_value=mock_resp)
+
+        callback = MagicMock()
+        download_and_extract(
+            "https://example.com/test.tar.gz",
+            str(tmp_path / "dest2"),
+            progress_callback=callback,
+        )
+
+        callback.assert_called()
+
+    def test_raises_on_download_failure(self, mocker, tmp_path):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = Exception("Download failed")
+        mocker.patch("requests.get", return_value=mock_resp)
+
+        with pytest.raises(Exception, match="Download failed"):
+            download_and_extract(
+                "https://example.com/test.tar.gz",
+                str(tmp_path / "dest3"),
+            )

--- a/tests/backend/test_engine.py
+++ b/tests/backend/test_engine.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 from src.backend.analysis.engine import (
     EngineManager,
@@ -5,6 +6,8 @@ from src.backend.analysis.engine import (
     DEFAULT_HASH_MB,
     engine_options,
     options_from_config,
+    resolve_engine_path,
+    _validate_engine_path,
 )
 import chess.engine
 
@@ -64,3 +67,256 @@ def test_apply_settings_from_config_without_manager_is_noop():
     manager = EngineManager("dummy_path")
     # No exception means the noop worked.
     manager.apply_settings_from_config()
+
+
+# ── resolve_engine_path ─────────────────────────────────────────────────
+
+class TestValidateEnginePath:
+    def test_none_or_empty_returns_false(self):
+        assert _validate_engine_path("") is False
+
+    def test_nonexistent_file_returns_false(self):
+        assert _validate_engine_path("/nonexistent/stockfish") is False
+
+    def test_valid_file_returns_true(self, tmp_path):
+        p = tmp_path / "stockfish"
+        p.write_text("fake binary")
+        p.chmod(0o755)
+        assert _validate_engine_path(str(p)) is True
+
+    def test_non_executable_on_unix_returns_false(self, mocker, tmp_path):
+        mocker.patch.object(sys, "platform", "linux")
+        p = tmp_path / "stockfish"
+        p.write_text("fake binary")
+        p.chmod(0o644)
+        assert _validate_engine_path(str(p)) is False
+
+    def test_windows_skips_exec_check(self, mocker, tmp_path):
+        mocker.patch.object(sys, "platform", "win32")
+        p = tmp_path / "stockfish.exe"
+        p.write_text("fake binary")
+        # Not setting executable bits — Windows doesn't care
+        assert _validate_engine_path(str(p)) is True
+
+
+class TestResolveEnginePath:
+    """Tests the priority-based resolution (no real filesystem access)."""
+
+    def test_priority1_config_path(self, mocker):
+        """Config path that exists is returned first."""
+        mock_cfg = mocker.Mock()
+        mock_cfg.get.return_value = "/usr/local/bin/stockfish"
+
+        mocker.patch("shutil.which", return_value=None)
+        mocker.patch("os.path.isfile", return_value=True)
+        mocker.patch("os.access", return_value=True)
+
+        result = resolve_engine_path(mock_cfg)
+        assert result == "/usr/local/bin/stockfish"
+        mock_cfg.get.assert_called_with("engine_path", "")
+
+    def test_priority1_config_path_which_resolves(self, mocker):
+        """If config path is a bare name, shutil.which resolves it."""
+        mock_cfg = mocker.Mock()
+        mock_cfg.get.return_value = "stockfish"
+
+        mocker.patch("shutil.which", return_value="/opt/homebrew/bin/stockfish")
+        mocker.patch("os.path.isfile", return_value=True)
+        mocker.patch("os.access", return_value=True)
+
+        result = resolve_engine_path(mock_cfg)
+        assert result == "/opt/homebrew/bin/stockfish"
+
+    def test_priority1_skips_when_config_empty(self, mocker):
+        """Empty config path falls through to PATH lookup."""
+        mock_cfg = mocker.Mock()
+        mock_cfg.get.return_value = ""
+
+        mocker.patch("shutil.which", return_value=None)
+        mocker.patch("os.path.isfile", return_value=False)
+        mocker.patch("src.backend.analysis.engine.get_stockfish_common_paths",
+                     return_value=[])
+        mocker.patch("src.backend.analysis.engine.get_engine_data_dir",
+                     return_value="/tmp/engine_data")
+
+        result = resolve_engine_path(mock_cfg)
+        # Falls all the way through to None since nothing is found
+        assert result is None
+
+    def test_priority1_skips_when_config_path_invalid(self, mocker):
+        """Config path that doesn't exist falls through."""
+        mock_cfg = mocker.Mock()
+        mock_cfg.get.return_value = "/usr/local/bin/stockfish"
+
+        mocker.patch("shutil.which", return_value=None)
+        mocker.patch("os.path.isfile", return_value=False)
+
+        result = resolve_engine_path(mock_cfg)
+        assert result is None
+
+    def test_priority2_path_lookup(self, mocker):
+        """shutil.which result is returned before common paths."""
+        mock_cfg = mocker.Mock()
+        mock_cfg.get.return_value = ""
+
+        mocker.patch("shutil.which", return_value="/usr/bin/stockfish")
+        mocker.patch("os.path.isfile", return_value=True)
+        mocker.patch("os.access", return_value=True)
+
+        result = resolve_engine_path(mock_cfg)
+        assert result == "/usr/bin/stockfish"
+
+    def test_priority2_path_lookup_second_place(self, mocker):
+        """shutil.which returning None -> skip to common paths."""
+        mock_cfg = mocker.Mock()
+        mock_cfg.get.return_value = ""
+
+        mocker.patch("shutil.which", return_value=None)
+        mocker.patch("os.path.isfile", return_value=True)
+        mocker.patch("os.access", return_value=True)
+        mocker.patch("src.backend.analysis.engine.get_stockfish_common_paths",
+                     return_value=["/opt/homebrew/bin/stockfish"])
+        mocker.patch("src.backend.analysis.engine.get_engine_data_dir",
+                     return_value="/tmp/data/engine")
+
+        result = resolve_engine_path(mock_cfg)
+        assert result == "/opt/homebrew/bin/stockfish"
+
+    def test_priority3_common_paths_checked(self, mocker):
+        """Common paths are checked after PATH."""
+        mock_cfg = mocker.Mock()
+        mock_cfg.get.return_value = ""
+
+        def which_side_effect(cmd, **kw):
+            return None
+
+        mocker.patch("shutil.which", side_effect=which_side_effect)
+
+        # Make first common path valid
+        mocker.patch("src.backend.analysis.engine.get_stockfish_common_paths",
+                     return_value=["/opt/homebrew/bin/stockfish",
+                                   "/usr/local/bin/stockfish"])
+
+        def isfile_side_effect(p):
+            return p == "/opt/homebrew/bin/stockfish"
+
+        mocker.patch("os.path.isfile", side_effect=isfile_side_effect)
+        mocker.patch("os.access", return_value=True)
+
+        result = resolve_engine_path(mock_cfg)
+        assert result == "/opt/homebrew/bin/stockfish"
+
+    def test_priority4_downloaded_dir(self, mocker):
+        """Previously-downloaded binary in engine data dir is found."""
+        mock_cfg = mocker.Mock()
+        mock_cfg.get.return_value = ""
+
+        mocker.patch("shutil.which", return_value=None)
+        mocker.patch("src.backend.analysis.engine.get_stockfish_common_paths",
+                     return_value=[])
+        mocker.patch("src.backend.analysis.engine.get_engine_data_dir",
+                     return_value="/tmp/engine_data")
+        mocker.patch("os.path.isfile", return_value=True)
+        mocker.patch("os.access", return_value=True)
+
+        result = resolve_engine_path(mock_cfg)
+        assert result == "/tmp/engine_data/stockfish"
+
+    def test_all_priorities_fail_returns_none(self, mocker):
+        """When nothing is found, returns None."""
+        mock_cfg = mocker.Mock()
+        mock_cfg.get.return_value = ""
+
+        mocker.patch("shutil.which", return_value=None)
+        mocker.patch("src.backend.analysis.engine.get_stockfish_common_paths",
+                     return_value=[])
+        mocker.patch("src.backend.analysis.engine.get_engine_data_dir",
+                     return_value="/tmp/engine_data")
+        mocker.patch("os.path.isfile", return_value=False)
+
+        result = resolve_engine_path(mock_cfg)
+        assert result is None
+
+    def test_no_config_manager_uses_fallback(self, mocker):
+        """When config_manager is None, skips priority 1 and goes to PATH."""
+        mocker.patch("shutil.which", return_value="/usr/bin/stockfish")
+        mocker.patch("os.path.isfile", return_value=True)
+        mocker.patch("os.access", return_value=True)
+
+        result = resolve_engine_path(None)
+        assert result == "/usr/bin/stockfish"
+
+    def test_no_config_manager_falls_through(self, mocker):
+        """When config_manager is None and no PATH match, goes to common paths."""
+        mocker.patch("shutil.which", return_value=None)
+        mocker.patch("src.backend.analysis.engine.get_stockfish_common_paths",
+                     return_value=["/usr/local/bin/stockfish"])
+        mocker.patch("os.path.isfile", return_value=True)
+        mocker.patch("os.access", return_value=True)
+
+        result = resolve_engine_path(None)
+        assert result == "/usr/local/bin/stockfish"
+
+
+# ── recheck_engine_path ─────────────────────────────────────────────────
+
+class TestRecheckEnginePath:
+    def test_finds_engine_and_starts_it(self, mocker):
+        """If resolve finds a path, engine is started."""
+        mocker.patch("src.backend.analysis.engine.resolve_engine_path",
+                     return_value="/usr/bin/stockfish")
+        manager = EngineManager("old/path")
+        mocker.patch.object(manager, "start_engine",
+                            side_effect=lambda: setattr(manager, "engine", mocker.Mock()))
+
+        result = manager.recheck_engine_path()
+        assert result is True
+        assert manager.engine_path == "/usr/bin/stockfish"
+
+    def test_path_unchanged_and_engine_running(self, mocker):
+        """Same path and engine already running -> returns True, no restart."""
+        mocker.patch("src.backend.analysis.engine.resolve_engine_path",
+                     return_value="/same/path")
+        manager = EngineManager("/same/path")
+        manager.engine = mocker.Mock()
+
+        start_mock = mocker.patch.object(manager, "start_engine")
+        stop_mock = mocker.patch.object(manager, "stop_engine")
+
+        result = manager.recheck_engine_path()
+        assert result is True
+        stop_mock.assert_not_called()
+        start_mock.assert_not_called()
+
+    def test_path_changed_restarts_engine(self, mocker):
+        """Different path -> stops old, starts new."""
+        mocker.patch("src.backend.analysis.engine.resolve_engine_path",
+                     return_value="/new/path")
+        manager = EngineManager("/old/path")
+        manager.engine = mocker.Mock()
+        mocker.patch.object(manager, "start_engine",
+                            side_effect=lambda: setattr(manager, "engine", mocker.Mock()))
+
+        result = manager.recheck_engine_path()
+        assert result is True
+        assert manager.engine_path == "/new/path"
+
+    def test_returns_false_when_not_found(self, mocker):
+        """resolve returns None -> returns False."""
+        mocker.patch("src.backend.analysis.engine.resolve_engine_path",
+                     return_value=None)
+        manager = EngineManager("/old/path")
+
+        result = manager.recheck_engine_path()
+        assert result is False
+
+    def test_returns_false_when_start_fails(self, mocker):
+        """start_engine raises -> returns False."""
+        mocker.patch("src.backend.analysis.engine.resolve_engine_path",
+                     return_value="/new/path")
+        manager = EngineManager("/old/path")
+        mocker.patch.object(manager, "start_engine",
+                            side_effect=Exception("engine crash"))
+
+        result = manager.recheck_engine_path()
+        assert result is False

--- a/tests/utils/test_path_utils.py
+++ b/tests/utils/test_path_utils.py
@@ -1,0 +1,48 @@
+import sys
+import pytest
+from src.utils.path_utils import (
+    get_stockfish_common_paths,
+    get_engine_data_dir,
+    get_user_data_dir,
+)
+
+
+class TestGetStockfishCommonPaths:
+    def test_returns_list(self):
+        paths = get_stockfish_common_paths()
+        assert isinstance(paths, list)
+        assert len(paths) > 0
+
+    def test_macos_paths(self, mocker):
+        mocker.patch.object(sys, "platform", "darwin")
+        paths = get_stockfish_common_paths()
+        assert "/opt/homebrew/bin/stockfish" in paths
+        assert "/usr/local/bin/stockfish" in paths
+
+    def test_windows_paths(self, mocker):
+        mocker.patch.object(sys, "platform", "win32")
+        paths = get_stockfish_common_paths()
+        assert any(p.endswith("stockfish.exe") for p in paths)
+        assert "C:\\Program Files\\Stockfish\\stockfish.exe" in paths
+
+    def test_linux_paths(self, mocker):
+        mocker.patch.object(sys, "platform", "linux")
+        paths = get_stockfish_common_paths()
+        assert "/usr/bin/stockfish" in paths
+        assert "/usr/local/bin/stockfish" in paths
+
+
+class TestGetEngineDataDir:
+    def test_returns_subdir_of_user_data_dir(self, mocker):
+        mocker.patch("src.utils.path_utils.get_user_data_dir", return_value="/base/data")
+        mocker.patch("os.makedirs")
+        engine_dir = get_engine_data_dir()
+        assert engine_dir == "/base/data/engine"
+
+    def test_creates_directory(self, mocker, tmp_path):
+        base = str(tmp_path / "data")
+        mocker.patch("src.utils.path_utils.get_user_data_dir", return_value=base)
+        engine_dir = get_engine_data_dir()
+        assert engine_dir == f"{base}/engine"
+        import os
+        assert os.path.isdir(engine_dir)


### PR DESCRIPTION
## Description

Backend infrastructure for automatically finding or downloading Stockfish — no visible UI changes in this PR.

**Priority table:**

| Priority | Check |
|----------|-------|
| 1 | `config["engine_path"]` — explicit user setting |
| 2 | `shutil.which("stockfish")` — PATH (Homebrew, system) |
| 3 | Platform-specific common paths |
| 4 | Previously downloaded in engine data dir |
| 5 | `None` → caller prompts download |

**Design notes:**
- Universal binaries per OS (runtime CPU dispatch, no AVX2/BMI2/SSE41 detection)
- Python `requests.get()` doesn't set macOS quarantine (researched & confirmed)
- Downloader uses `stream=True` with progress callback for future UI

Fixes # (N/A — preparatory infrastructure)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] I have run the existing tests (e.g., pytest)
- [x] I have added new tests that prove my fix is effective or that my feature works

**Result:** 242 passed in 4.80s

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings