### PR TITLE
Feat/settings polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ installers/mac/Output
 .agent/**/.log
 .agent/.DS_Store
 .agent/Thumbs.db
+.opencode/*

--- a/main.py
+++ b/main.py
@@ -114,6 +114,8 @@ def main():
             if wizard.exec() == QDialog.DialogCode.Accepted:
                 wizard.accepted_data()
                 logger.info("Setup wizard completed successfully")
+                if hasattr(window, 'settings_view') and hasattr(window.settings_view, 'reload_from_config'):
+                    window.settings_view.reload_from_config()
             else:
                 logger.info("Setup wizard skipped")
             window._refresh_engine_status()

--- a/src/backend/analysis/analyzer.py
+++ b/src/backend/analysis/analyzer.py
@@ -14,6 +14,7 @@ from src.utils.path_utils import get_resource_path, get_user_data_dir
 from typing import Optional, List, Dict
 import math
 
+from src.constants import DEFAULT_MULTI_PV, DEFAULT_ANALYSIS_DEPTH
 from .math_utils import (
     get_win_probability,
     calculate_move_accuracy,
@@ -35,22 +36,23 @@ class Analyzer:
         db_path = os.path.join(get_user_data_dir(), "openings.db")
         self._opening_db = OpeningDB(db_path)
         try:
-            self._opening_db.initialize(tsv_dir)
+            just_populated = self._opening_db.initialize(tsv_dir)
         except FileNotFoundError:
             logger.warning(f"Opening TSV files not found in {tsv_dir}; book detection disabled")
         self.local_book = LocalBookManager(self._opening_db)
         polyglot_path = self.config_manager.get("polyglot_book_path", "")
         self.polyglot_book = PolyglotBookManager(polyglot_path)
-        logger.info(f"Opening book initialized: local SQLite at {db_path} ({'populated' if self._opening_db.is_populated() else 'empty'})")
+        if just_populated:
+            logger.info(f"Opening book populated: {db_path}")
         self.config = {
             "time_per_move": self.config_manager.get("time_per_move", 1.0),
-            "depth": self.config_manager.get("analysis_depth", 18),
+            "depth": self.config_manager.get("analysis_depth", DEFAULT_ANALYSIS_DEPTH),
             # multi_pv is read from user config (default 1) so the same
             # default applies to the Game Analysis tab.  See issue #5:
             # the previous hard-coded 3 was identified as a primary cause
             # of laptop overheating because evaluating 3 PVs roughly
             # triples the search tree.
-            "multi_pv": self.config_manager.get("multi_pv", 1),
+            "multi_pv": self.config_manager.get("multi_pv", DEFAULT_MULTI_PV),
             "use_cache": True
         }
 
@@ -87,8 +89,8 @@ class Analyzer:
         """
         # Refresh configuration from global settings before starting
         self.config["time_per_move"] = self.config_manager.get("time_per_move", 1.0)
-        self.config["depth"] = self.config_manager.get("analysis_depth", 18)
-        self.config["multi_pv"] = self.config_manager.get("multi_pv", 1)
+        self.config["depth"] = self.config_manager.get("analysis_depth", DEFAULT_ANALYSIS_DEPTH)
+        self.config["multi_pv"] = self.config_manager.get("multi_pv", DEFAULT_MULTI_PV)
         
         # Update Polyglot book path from settings if changed
         new_polyglot_path = self.config_manager.get("polyglot_book_path", "")

--- a/src/backend/analysis/engine.py
+++ b/src/backend/analysis/engine.py
@@ -6,13 +6,7 @@ import shutil
 from typing import Optional, Dict, Any, Tuple, List
 from src.utils.logger import logger
 from src.utils.path_utils import get_stockfish_common_paths, get_engine_data_dir
-
-# Conservative defaults aimed at laptops (incl. fanless MacBook Air).
-# Power users can raise these in Settings; the values here are deliberately
-# small so that a stock install does not pin every core at 100% forever.
-# See https://github.com/imutkarsht/Chess_analyzer/issues/5
-DEFAULT_THREADS = min(os.cpu_count() or 1, 4)
-DEFAULT_HASH_MB = 64
+from src.constants import DEFAULT_ENGINE_THREADS, DEFAULT_ENGINE_HASH_MB
 
 
 def engine_options(threads: int, hash_mb: int) -> Dict[str, Any]:
@@ -31,9 +25,9 @@ def options_from_config(config_manager=None) -> Dict[str, Any]:
     the keys (e.g. on a fresh install) or if it is not provided.
     """
     if config_manager is None:
-        return engine_options(DEFAULT_THREADS, DEFAULT_HASH_MB)
-    threads = config_manager.get("engine_threads", DEFAULT_THREADS)
-    hash_mb = config_manager.get("engine_hash", DEFAULT_HASH_MB)
+        return engine_options(DEFAULT_ENGINE_THREADS, DEFAULT_ENGINE_HASH_MB)
+    threads = config_manager.get("engine_threads", DEFAULT_ENGINE_THREADS)
+    hash_mb = config_manager.get("engine_hash", DEFAULT_ENGINE_HASH_MB)
     return engine_options(threads, hash_mb)
 
 
@@ -54,6 +48,21 @@ def invalidate_engine_cache() -> None:
     _resolve_cache = None
 
 
+def _save_fallback_to_config(config_manager, resolved_path: str) -> None:
+    """If the config still holds a stale path, overwrite it with the
+    working fallback so the Settings UI stays in sync."""
+    if config_manager is None:
+        return
+    current = config_manager.get("engine_path", "")
+    if current and current != resolved_path:
+        logger.info(
+            "resolve_engine_path: updating config from '%s' to fallback '%s'",
+            current, resolved_path,
+        )
+        config_manager.config["engine_path"] = resolved_path
+        config_manager.save_config()
+
+
 def resolve_engine_path(config_manager=None) -> Optional[str]:
     """Auto-detect a Stockfish binary using the priority table.
     Result is cached for the lifetime of the process (call
@@ -67,6 +76,8 @@ def resolve_engine_path(config_manager=None) -> Optional[str]:
     | 4        | Already-downloaded in engine data dir |
     | 5        | ``None`` – caller should fall back to download |
 
+    When a fallback path is used (priorities 2-4), the config is updated
+    so the Settings UI reflects the working path on next load.
     Returns the path string or ``None`` if nothing was found.
     """
     global _resolve_cache
@@ -87,6 +98,7 @@ def resolve_engine_path(config_manager=None) -> Optional[str]:
     which_path = shutil.which("stockfish")
     if which_path and _validate_engine_path(which_path):
         logger.info("resolve_engine_path: found via PATH at %s", which_path)
+        _save_fallback_to_config(config_manager, which_path)
         _resolve_cache = which_path
         return which_path
 
@@ -94,6 +106,7 @@ def resolve_engine_path(config_manager=None) -> Optional[str]:
     for candidate in get_stockfish_common_paths():
         if _validate_engine_path(candidate):
             logger.info("resolve_engine_path: found at common path %s", candidate)
+            _save_fallback_to_config(config_manager, candidate)
             _resolve_cache = candidate
             return candidate
 
@@ -101,6 +114,7 @@ def resolve_engine_path(config_manager=None) -> Optional[str]:
     downloaded = os.path.join(get_engine_data_dir(), "stockfish")
     if _validate_engine_path(downloaded):
         logger.info("resolve_engine_path: found previously downloaded at %s", downloaded)
+        _save_fallback_to_config(config_manager, downloaded)
         _resolve_cache = downloaded
         return downloaded
 
@@ -183,8 +197,8 @@ class EngineManager:
         if self.config_manager is None:
             return
         self.apply_settings(
-            threads=self.config_manager.get("engine_threads", DEFAULT_THREADS),
-            hash_mb=self.config_manager.get("engine_hash", DEFAULT_HASH_MB),
+            threads=self.config_manager.get("engine_threads", DEFAULT_ENGINE_THREADS),
+            hash_mb=self.config_manager.get("engine_hash", DEFAULT_ENGINE_HASH_MB),
         )
 
     def recheck_engine_path(self, config_manager=None) -> bool:

--- a/src/backend/analysis/opening_db.py
+++ b/src/backend/analysis/opening_db.py
@@ -79,17 +79,20 @@ class OpeningDB:
         ).fetchone()
         return row["cnt"] > 0
 
-    def initialize(self, tsv_dir: str):
-        """Populate the database from TSV files if not already populated."""
+    def initialize(self, tsv_dir: str) -> bool:
+        """Populate the database from TSV files if not already populated.
+        Returns True if the DB was populated by this call, False if already populated.
+        """
         self.connect()
         if self.is_populated():
-            return
+            return False
         self._import_tsvs(tsv_dir)
         self._conn.execute(
             "INSERT INTO opening_book_metadata (version, imported_at) VALUES (?, datetime('now'))",
             (self.CURRENT_VERSION,),
         )
         self._conn.commit()
+        return True
 
     # ---- TSV Import ----
 

--- a/src/backend/storage/cache.py
+++ b/src/backend/storage/cache.py
@@ -2,6 +2,7 @@ import sqlite3
 import json
 import hashlib
 from typing import Optional, Dict, Any
+from src.constants import DEFAULT_MULTI_PV
 
 class AnalysisCache:
     def __init__(self, db_path: Optional[str] = None):
@@ -52,7 +53,7 @@ class AnalysisCache:
         Returns cached result only if cached_depth >= requested_depth.
         """
         requested_depth = engine_params.get("depth", 0) or 0
-        multi_pv = engine_params.get("multi_pv", 1)
+        multi_pv = engine_params.get("multi_pv", DEFAULT_MULTI_PV)
         key = self._generate_key(fen, multi_pv)
         
         cursor = self.conn.cursor()
@@ -71,7 +72,7 @@ class AnalysisCache:
         Save analysis to cache. Overwrites if new depth is higher than cached depth.
         """
         new_depth = engine_params.get("depth", 0) or 0
-        multi_pv = engine_params.get("multi_pv", 1)
+        multi_pv = engine_params.get("multi_pv", DEFAULT_MULTI_PV)
         key = self._generate_key(fen, multi_pv)
         
         cursor = self.conn.cursor()

--- a/src/constants.py
+++ b/src/constants.py
@@ -49,6 +49,13 @@ PLATFORM_RULES = {
     },
 }
 
+# Engine Defaults (conservative — see issue #5)
+DEFAULT_ENGINE_THREADS = 1
+DEFAULT_ENGINE_HASH_MB = 128
+DEFAULT_MULTI_PV = 2
+DEFAULT_LIVE_ANALYSIS_TIME = 0.5
+DEFAULT_ANALYSIS_DEPTH = 18
+
 # LLM Providers Catalogue
 PROVIDERS = {
     "groq": {

--- a/src/gui/analysis/analysis_panel.py
+++ b/src/gui/analysis/analysis_panel.py
@@ -3,7 +3,7 @@ Analysis Panel - Coordinates evaluation graphs, stats summaries, and AI coach su
 """
 import chess
 from PyQt6.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QFrame, QTabWidget, 
-                             QSizePolicy, QLabel, QGridLayout, QPushButton, QTextEdit, QMessageBox)
+                             QSizePolicy, QLabel, QGridLayout, QPushButton, QTextEdit, QMessageBox, QDialog)
 from PyQt6.QtCore import pyqtSignal, Qt, QThread
 from src.gui.styles import Styles
 from src.gui.utils.gui_utils import (clear_layout, show_error_dialog, is_error_message, 
@@ -90,13 +90,16 @@ class AnalysisPanel(QWidget):
         
         # --- Tab 2: Report ---
         self.report_tab = QWidget()
+        self.report_tab.setStyleSheet("background: transparent;")
         self.report_layout = QVBoxLayout(self.report_tab)
         self.report_layout.setContentsMargins(5, 5, 5, 5)
         self.report_layout.setSpacing(10)
         
         # Opening
         self.opening_label = QLabel("Opening: -")
-        self.opening_label.setStyleSheet(f"color: {Styles.COLOR_TEXT_SECONDARY}; font-size: 14px; font-weight: bold;")
+        self.opening_label.setStyleSheet(
+            f"color: {Styles.COLOR_TEXT_SECONDARY}; font-size: 14px; font-weight: bold; background: transparent;"
+        )
         self.opening_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.opening_label.setWordWrap(True)
         self.report_layout.addWidget(self.opening_label)
@@ -301,12 +304,21 @@ class AnalysisPanel(QWidget):
             self.current_game.ai_summary = ""
             self.txt_ai_summary.setVisible(False)
             self.btn_generate_summary.setVisible(True)
-            show_error_dialog(
-                self,
-                "AI Summary Failed",
-                "Could not generate the AI summary.",
-                summary,
-            )
+            if "not configured" in summary.lower():
+                from ..dialogs.llm_error_dialog import LlmNotConfiguredDialog
+                dlg = LlmNotConfiguredDialog(self)
+                if dlg.exec() == QDialog.DialogCode.Accepted and dlg.wants_configure():
+                    window = self.window()
+                    if hasattr(window, "sidebar") and hasattr(window, "switch_page"):
+                        window.sidebar.set_active(4)
+                        window.switch_page(4)
+            else:
+                show_error_dialog(
+                    self,
+                    "AI Summary Failed",
+                    "Could not generate the AI summary.",
+                    summary,
+                )
             return
 
         logger.info("AI Summary generated successfully.")

--- a/src/gui/analysis/live_analysis.py
+++ b/src/gui/analysis/live_analysis.py
@@ -2,6 +2,7 @@ import chess
 import chess.engine
 from PyQt6.QtCore import QThread, pyqtSignal, QMutex, QWaitCondition
 from src.utils.logger import logger
+from src.constants import DEFAULT_LIVE_ANALYSIS_TIME, DEFAULT_MULTI_PV, DEFAULT_ANALYSIS_DEPTH, DEFAULT_ENGINE_THREADS, DEFAULT_ENGINE_HASH_MB
 import time
 
 
@@ -40,33 +41,33 @@ class LiveAnalysisWorker(QThread):
     def _live_time(self) -> float:
         if self.config_manager is not None:
             try:
-                return float(self.config_manager.get("live_analysis_time", 2.0))
+                return float(self.config_manager.get("live_analysis_time", DEFAULT_LIVE_ANALYSIS_TIME))
             except (TypeError, ValueError):
                 pass
-        return 2.0
+        return DEFAULT_LIVE_ANALYSIS_TIME
 
     def _live_multi_pv(self) -> int:
         if self.config_manager is not None:
             try:
-                value = int(self.config_manager.get("multi_pv", 1))
+                value = int(self.config_manager.get("multi_pv", DEFAULT_MULTI_PV))
                 if value >= 1:
                     return value
             except (TypeError, ValueError):
                 pass
-        return 1
+        return DEFAULT_MULTI_PV
         
     def _live_depth(self) -> int:
         if self.config_manager is not None:
             try:
-                return int(self.config_manager.get("analysis_depth", 18))
+                return int(self.config_manager.get("analysis_depth", DEFAULT_ANALYSIS_DEPTH))
             except (TypeError, ValueError):
                 pass
-        return 18
+        return DEFAULT_ANALYSIS_DEPTH
 
     def _threads(self) -> int:
         if self.config_manager is not None:
             try:
-                return int(self.config_manager.get("engine_threads", 1))
+                return int(self.config_manager.get("engine_threads", DEFAULT_ENGINE_THREADS))
             except (TypeError, ValueError):
                 pass
         return 1
@@ -74,10 +75,10 @@ class LiveAnalysisWorker(QThread):
     def _hash(self) -> int:
         if self.config_manager is not None:
             try:
-                return int(self.config_manager.get("engine_hash", 32))
+                return int(self.config_manager.get("engine_hash", DEFAULT_ENGINE_HASH_MB))
             except (TypeError, ValueError):
                 pass
-        return 32
+        return DEFAULT_ENGINE_HASH_MB
 
     def configure_engine(self):
         """Reconfigures engine Thread and Hash options dynamically."""

--- a/src/gui/components/tour_overlay.py
+++ b/src/gui/components/tour_overlay.py
@@ -117,10 +117,10 @@ class TourOverlay(QWidget):
         self.next_btn.clicked.connect(self._on_next)
         nav.addWidget(self.next_btn)
 
-        close_btn = QPushButton("✕")
-        close_btn.setToolTip("Close tour  (Esc)")
-        close_btn.setCursor(Qt.CursorShape.PointingHandCursor)
-        close_btn.setStyleSheet(f"""
+        self.close_btn = QPushButton("✕")
+        self.close_btn.setToolTip("Close tour  (Esc)")
+        self.close_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.close_btn.setStyleSheet(f"""
             QPushButton {{
                 background-color: transparent;
                 color: #9CA3AF;
@@ -131,8 +131,8 @@ class TourOverlay(QWidget):
             }}
             QPushButton:hover {{ color: #FFFFFF; border-color: {Styles.COLOR_ACCENT}; }}
         """)
-        close_btn.clicked.connect(self._on_close)
-        nav.addWidget(close_btn)
+        self.close_btn.clicked.connect(self._on_close)
+        nav.addWidget(self.close_btn)
 
         layout.addLayout(nav)
         self.bubble.hide()
@@ -146,6 +146,53 @@ class TourOverlay(QWidget):
         self.bubble.raise_()
         self._pulse_timer.start()
         self._show_step()
+
+    def refresh_accent(self):
+        self.bubble.setStyleSheet(f"""
+            QFrame#TourBubble {{
+                background-color: {Styles.COLOR_SURFACE};
+                border: 2px solid {Styles.COLOR_ACCENT};
+                border-radius: 14px;
+            }}
+            QFrame#TourBubble QLabel {{
+                background: transparent;
+            }}
+        """)
+        self.next_btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {Styles.COLOR_ACCENT};
+                color: white;
+                border: none;
+                border-radius: 6px;
+                padding: 7px 22px;
+                font-size: 13px;
+                font-weight: bold;
+            }}
+            QPushButton:hover {{ background-color: {Styles.COLOR_ACCENT_HOVER}; }}
+        """)
+        self.prev_btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {Styles.COLOR_SURFACE_LIGHT};
+                color: #FFFFFF;
+                border: 1px solid {Styles.COLOR_BORDER};
+                border-radius: 6px;
+                padding: 7px 16px;
+                font-size: 13px;
+            }}
+            QPushButton:hover {{ border-color: {Styles.COLOR_ACCENT}; }}
+            QPushButton:disabled {{ color: #6B7280; border-color: {Styles.COLOR_BORDER}; }}
+        """)
+        self.close_btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: transparent;
+                color: #9CA3AF;
+                border: 1px solid {Styles.COLOR_BORDER};
+                border-radius: 6px;
+                padding: 7px 11px;
+                font-size: 13px;
+            }}
+            QPushButton:hover {{ color: #FFFFFF; border-color: {Styles.COLOR_ACCENT}; }}
+        """)
 
     # ── Internal ─────────────────────────────────────────────────────────
 

--- a/src/gui/dialogs/engine_error_dialog.py
+++ b/src/gui/dialogs/engine_error_dialog.py
@@ -1,0 +1,250 @@
+"""
+Error dialog for when the chess engine is not found,
+offering Auto-detect, Download, and Browse actions.
+"""
+import os
+from PyQt6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
+    QFileDialog, QProgressBar, QApplication
+)
+from PyQt6.QtCore import Qt, QTimer
+from ...backend.analysis.engine import resolve_engine_path, invalidate_engine_cache
+from ...backend.engine.downloader import (
+    get_official_releases, get_expected_asset_name, get_download_url,
+    download_and_extract
+)
+from ...utils.path_utils import get_engine_data_dir
+from ...utils.logger import logger
+from ..styles import Styles
+
+BUTTON_STYLE = f"""
+    QPushButton {{
+        background-color: {Styles.COLOR_SURFACE_LIGHT};
+        color: {Styles.COLOR_TEXT_PRIMARY};
+        border: 1px solid {Styles.COLOR_BORDER};
+        padding: 10px 18px;
+        border-radius: 6px;
+        font-size: 13px;
+        font-weight: 500;
+        text-align: left;
+    }}
+    QPushButton:hover {{
+        background-color: {Styles.COLOR_SURFACE};
+        border-color: {Styles.COLOR_ACCENT};
+    }}
+    QPushButton:disabled {{
+        color: {Styles.COLOR_TEXT_MUTED};
+    }}
+"""
+
+PRIMARY_BUTTON_STYLE = f"""
+    QPushButton {{
+        background-color: {Styles.COLOR_ACCENT};
+        color: white;
+        border: none;
+        padding: 8px 16px;
+        border-radius: 6px;
+        font-size: 13px;
+        font-weight: 600;
+    }}
+    QPushButton:hover {{
+        background-color: {Styles.COLOR_ACCENT_HOVER};
+    }}
+"""
+
+
+class EngineNotFoundDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Engine Not Found")
+        self.setFixedSize(520, 340)
+        self.setStyleSheet(f"""
+            QDialog {{
+                background-color: {Styles.COLOR_BACKGROUND};
+                color: {Styles.COLOR_TEXT_PRIMARY};
+            }}
+        """)
+
+        self._result_action = None
+        self._engine_path = None
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(28, 28, 28, 20)
+        layout.setSpacing(16)
+
+        icon_lbl = QLabel("\u26CF")
+        icon_lbl.setStyleSheet("font-size: 36px; background: transparent;")
+        icon_lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(icon_lbl)
+
+        title = QLabel("Stockfish Engine Not Found")
+        title.setStyleSheet(
+            f"font-size: 18px; font-weight: bold; color: {Styles.COLOR_TEXT_PRIMARY}; "
+            f"background: transparent;"
+        )
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(title)
+
+        desc = QLabel(
+            "No working Stockfish engine was found. Analysis requires a Stockfish "
+            "chess engine binary on your system."
+        )
+        desc.setWordWrap(True)
+        desc.setStyleSheet(
+            f"font-size: 13px; color: {Styles.COLOR_TEXT_SECONDARY}; "
+            f"background: transparent;"
+        )
+        desc.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(desc)
+
+        self._progress = QProgressBar()
+        self._progress.setVisible(False)
+        self._progress.setStyleSheet(Styles.get_progress_bar_style())
+        layout.addWidget(self._progress)
+
+        self._status = QLabel("")
+        self._status.setStyleSheet(
+            f"font-size: 12px; color: {Styles.COLOR_TEXT_SECONDARY}; "
+            f"background: transparent;"
+        )
+        self._status.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._status.setVisible(False)
+        layout.addWidget(self._status)
+
+        btn_layout = QVBoxLayout()
+        btn_layout.setSpacing(10)
+
+        self._auto_btn = QPushButton("  Auto-detect Stockfish")
+        self._auto_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._auto_btn.setStyleSheet(BUTTON_STYLE)
+        self._auto_btn.clicked.connect(self._auto_detect)
+        btn_layout.addWidget(self._auto_btn)
+
+        self._download_btn = QPushButton("  Download Stockfish")
+        self._download_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._download_btn.setStyleSheet(BUTTON_STYLE)
+        self._download_btn.clicked.connect(self._start_download)
+        btn_layout.addWidget(self._download_btn)
+
+        self._browse_btn = QPushButton("  Browse for Stockfish...")
+        self._browse_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._browse_btn.setStyleSheet(BUTTON_STYLE)
+        self._browse_btn.clicked.connect(self._browse)
+        btn_layout.addWidget(self._browse_btn)
+
+        layout.addLayout(btn_layout)
+
+        footer = QHBoxLayout()
+        footer.addStretch()
+        self._cancel_btn = QPushButton("Cancel")
+        self._cancel_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._cancel_btn.setStyleSheet(BUTTON_STYLE.replace("text-align: left;", ""))
+        self._cancel_btn.clicked.connect(self.reject)
+        footer.addWidget(self._cancel_btn)
+        layout.addLayout(footer)
+
+    def _set_buttons_enabled(self, enabled: bool):
+        for btn in (self._auto_btn, self._download_btn, self._browse_btn, self._cancel_btn):
+            btn.setEnabled(enabled)
+
+    def _auto_detect(self):
+        self._set_buttons_enabled(False)
+        self._status.setText("Scanning for Stockfish...")
+        self._status.setVisible(True)
+        QApplication.processEvents()
+
+        path = resolve_engine_path(self.config_manager()) if hasattr(self, 'config_manager') else None
+        if not path:
+            path = self._search_common_paths()
+
+        if path and os.path.isfile(path):
+            self._status.setText(f"Found: {path}")
+            self._status.setStyleSheet(
+                f"font-size: 12px; color: {Styles.COLOR_BEST}; "
+                f"background: transparent;"
+            )
+            self._engine_path = path
+            QTimer.singleShot(800, self.accept)
+        else:
+            self._status.setText("No Stockfish found on your system.")
+            self._status.setStyleSheet(
+                f"font-size: 12px; color: {Styles.COLOR_BLUNDER}; "
+                f"background: transparent;"
+            )
+            self._set_buttons_enabled(True)
+
+    def _search_common_paths(self):
+        import shutil
+        candidates = [
+            "stockfish",
+            shutil.which("stockfish"),
+            "/usr/local/bin/stockfish",
+            "/opt/homebrew/bin/stockfish",
+        ]
+        for c in candidates:
+            if c and (os.path.isfile(c) or shutil.which(c)):
+                return shutil.which(c) or c
+        return None
+
+    def _start_download(self):
+        self._set_buttons_enabled(False)
+        self._progress.setVisible(True)
+        self._progress.setValue(0)
+        self._status.setText("Checking for Stockfish releases...")
+        self._status.setVisible(True)
+        self._status.setStyleSheet(
+            f"font-size: 12px; color: {Styles.COLOR_TEXT_SECONDARY}; "
+            f"background: transparent;"
+        )
+        QApplication.processEvents()
+
+        try:
+            releases = get_official_releases()
+            target = get_expected_asset_name()
+            url = get_download_url(releases, target)
+            if not url:
+                raise RuntimeError(f"No download found for {target}")
+
+            dest_dir = get_engine_data_dir()
+            self._status.setText("Downloading Stockfish...")
+            QApplication.processEvents()
+
+            def progress(downloaded, total):
+                pct = int(downloaded / total * 100) if total else 0
+                self._progress.setValue(pct)
+
+            binary_path = download_and_extract(url, dest_dir, progress_callback=progress)
+            self._progress.setValue(100)
+
+            invalidate_engine_cache()
+            self._engine_path = binary_path
+            self._status.setText(f"Downloaded: {os.path.basename(binary_path)}")
+            self._status.setStyleSheet(
+                f"font-size: 12px; color: {Styles.COLOR_BEST}; "
+                f"background: transparent;"
+            )
+            QTimer.singleShot(600, self.accept)
+        except Exception as e:
+            logger.exception("EngineNotFoundDialog: download failed")
+            self._status.setText(f"Download failed: {e}")
+            self._status.setStyleSheet(
+                f"font-size: 12px; color: {Styles.COLOR_BLUNDER}; "
+                f"background: transparent;"
+            )
+            self._progress.setVisible(False)
+            self._set_buttons_enabled(True)
+
+    def _browse(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Select Stockfish Executable", "",
+            "All Files (*);;Executables (*)"
+        )
+        if path:
+            self._engine_path = path
+            self.accept()
+
+    def engine_path(self) -> str:
+        return self._engine_path
+
+    def result_action(self):
+        return self._result_action

--- a/src/gui/dialogs/llm_error_dialog.py
+++ b/src/gui/dialogs/llm_error_dialog.py
@@ -1,0 +1,100 @@
+"""
+Error dialog for when the LLM is not configured,
+offering Configure Now and Skip actions.
+"""
+from PyQt6.QtWidgets import QDialog, QVBoxLayout, QHBoxLayout, QLabel, QPushButton
+from PyQt6.QtCore import Qt
+from ..styles import Styles
+
+
+class LlmNotConfiguredDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("LLM Not Configured")
+        self.setFixedSize(440, 220)
+        self.setStyleSheet(f"""
+            QDialog {{
+                background-color: {Styles.COLOR_BACKGROUND};
+                color: {Styles.COLOR_TEXT_PRIMARY};
+            }}
+        """)
+
+        self._configured = False
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(28, 28, 28, 20)
+        layout.setSpacing(14)
+
+        title = QLabel("AI Features Require Configuration")
+        title.setStyleSheet(
+            f"font-size: 17px; font-weight: bold; color: {Styles.COLOR_TEXT_PRIMARY}; "
+            f"background: transparent;"
+        )
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(title)
+
+        desc = QLabel(
+            "AI-powered analysis (summaries, coach insights, and move explanations) "
+            "need an LLM provider API key. You can configure one in Settings."
+        )
+        desc.setWordWrap(True)
+        desc.setStyleSheet(
+            f"font-size: 13px; color: {Styles.COLOR_TEXT_SECONDARY}; "
+            f"background: transparent;"
+        )
+        desc.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(desc)
+
+        layout.addStretch()
+
+        btn_layout = QHBoxLayout()
+        btn_layout.addStretch()
+
+        self._skip_btn = QPushButton("Skip")
+        self._skip_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._skip_btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {Styles.COLOR_SURFACE_LIGHT};
+                color: {Styles.COLOR_TEXT_SECONDARY};
+                border: 1px solid {Styles.COLOR_BORDER};
+                padding: 8px 20px;
+                border-radius: 6px;
+                font-size: 13px;
+            }}
+            QPushButton:hover {{
+                background-color: {Styles.COLOR_SURFACE};
+                border-color: {Styles.COLOR_ACCENT};
+            }}
+        """)
+        self._skip_btn.clicked.connect(self.reject)
+        btn_layout.addWidget(self._skip_btn)
+
+        btn_layout.addSpacing(12)
+
+        self._configure_btn = QPushButton("  Configure Now")
+        self._configure_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._configure_btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {Styles.COLOR_ACCENT};
+                color: white;
+                border: none;
+                padding: 8px 20px;
+                border-radius: 6px;
+                font-size: 13px;
+                font-weight: 600;
+            }}
+            QPushButton:hover {{
+                background-color: {Styles.COLOR_ACCENT_HOVER};
+            }}
+        """)
+        self._configure_btn.clicked.connect(self._on_configure)
+        btn_layout.addWidget(self._configure_btn)
+
+        layout.addLayout(btn_layout)
+
+    def _on_configure(self):
+        self._configured = True
+        self.accept()
+
+    def wants_configure(self) -> bool:
+        return self._configured

--- a/src/gui/dialogs/setup_wizard.py
+++ b/src/gui/dialogs/setup_wizard.py
@@ -21,6 +21,7 @@ from src.gui.dialogs.wizard.wizard_pages import (
     build_gatekeeper_page,
     build_welcome_page,
     build_profile_page,
+    build_appearance_page,
     build_stockfish_page,
     build_llm_page,
     build_done_page,
@@ -38,7 +39,35 @@ class SetupWizard(QDialog):
 
         self.setWindowTitle("Chess Analyzer Pro - Setup")
         self.setFixedSize(self.WIZARD_WIDTH, self.WIZARD_HEIGHT)
-        self.setStyleSheet(f"""
+        self.setStyleSheet(self._build_stylesheet())
+
+        self._build_ui()
+        self._populate_from_config()
+        self._show_page(0)
+
+    def _build_ui(self):
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        self.stack = QStackedWidget()
+        self.stack.addWidget(build_gatekeeper_page(self))
+        self.stack.addWidget(build_welcome_page(self))
+        self.stack.addWidget(build_profile_page(self))
+        self.stack.addWidget(build_appearance_page(self))
+        self.stack.addWidget(build_stockfish_page(self))
+        self.stack.addWidget(build_llm_page(self))
+        self.stack.addWidget(build_done_page(self))
+        layout.addWidget(self.stack, 1)
+
+        self.nav_bar = WizardNavBar()
+        self.nav_bar.next_btn.clicked.connect(self._on_next)
+        self.nav_bar.back_btn.clicked.connect(self._on_back)
+        self.nav_bar.skip_btn.clicked.connect(self._on_skip)
+        layout.addWidget(self.nav_bar)
+
+    def _build_stylesheet(self):
+        return f"""
             SetupWizard {{
                 background-color: {Styles.COLOR_BACKGROUND};
             }}
@@ -56,31 +85,54 @@ class SetupWizard(QDialog):
             QLineEdit::placeholder {{
                 color: {Styles.COLOR_TEXT_MUTED};
             }}
-        """)
+        """
 
-        self._build_ui()
-        self._populate_from_config()
-        self._show_page(0)
-
-    def _build_ui(self):
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(0)
-
-        self.stack = QStackedWidget()
-        self.stack.addWidget(build_gatekeeper_page(self))
-        self.stack.addWidget(build_welcome_page(self))
-        self.stack.addWidget(build_profile_page(self))
-        self.stack.addWidget(build_stockfish_page(self))
-        self.stack.addWidget(build_llm_page(self))
-        self.stack.addWidget(build_done_page(self))
-        layout.addWidget(self.stack, 1)
-
-        self.nav_bar = WizardNavBar()
-        self.nav_bar.next_btn.clicked.connect(self._on_next)
-        self.nav_bar.back_btn.clicked.connect(self._on_back)
-        self.nav_bar.skip_btn.clicked.connect(self._on_skip)
-        layout.addWidget(self.nav_bar)
+    def refresh_accent(self):
+        self.setStyleSheet(self._build_stylesheet())
+        self.nav_bar.refresh_accent()
+        self.nav_bar.update(self.current_page)
+        if hasattr(self, 'done_btn'):
+            self.done_btn.setStyleSheet(f"""
+                QPushButton {{
+                    background-color: {Styles.COLOR_ACCENT};
+                    color: white;
+                    border: none;
+                    border-radius: 8px;
+                    padding: 12px 40px;
+                    font-size: 15px;
+                    font-weight: bold;
+                }}
+                QPushButton:hover {{ background-color: {Styles.COLOR_ACCENT_HOVER}; }}
+            """)
+        if hasattr(self, 'ready_label'):
+            self.ready_label.setStyleSheet(
+                f"font-size: 15px; color: {Styles.COLOR_ACCENT}; font-weight: bold; background: transparent;"
+            )
+        if hasattr(self, 'wizard_theme_combo'):
+            self.wizard_theme_combo.setStyleSheet(Styles.get_combobox_style())
+        if hasattr(self, 'llm_test_btn'):
+            self.llm_test_btn.setStyleSheet(Styles.get_control_button_style())
+        if hasattr(self, 'sf_download_btn'):
+            self.sf_download_btn.setStyleSheet(Styles.get_button_style())
+        if hasattr(self, 'provider_label'):
+            self.provider_label.setStyleSheet(
+                f"font-size: 14px; font-weight: bold; color: {Styles.COLOR_ACCENT}; background: transparent;"
+            )
+        if hasattr(self, 'wizard_accent_btn') and self.wizard_accent_color != "#FF9500":
+            c = self.wizard_accent_color
+            self.wizard_accent_btn.setStyleSheet(f"""
+                QPushButton {{
+                    background-color: {c};
+                    color: white;
+                    border: none;
+                    padding: 8px 16px;
+                    border-radius: 6px;
+                    font-size: 13px;
+                }}
+                QPushButton:hover {{
+                    background-color: {c}CC;
+                }}
+            """)
 
     def _show_page(self, index):
         self.current_page = index
@@ -100,7 +152,8 @@ class SetupWizard(QDialog):
 
     def _on_next(self):
         self._save_current_page()
-        if self.current_page == 5:
+        if self.current_page == 6:
+            self._persist_settings()
             self.accept()
         else:
             self._show_page(self.current_page + 1)
@@ -110,7 +163,7 @@ class SetupWizard(QDialog):
             self._show_page(self.current_page - 1)
 
     def _on_skip(self):
-        self._show_page(5)
+        self._show_page(6)
 
     def _on_finish(self):
         self._save_current_page()
@@ -123,6 +176,10 @@ class SetupWizard(QDialog):
             self.settings["chesscom_username"] = self.chesscom_input.text().strip()
             self.settings["lichess_username"] = self.lichess_input.text().strip()
             self.settings["lichess_token"] = self.lichess_token_input.text().strip()
+        elif idx == 3:
+            if hasattr(self, "wizard_theme_combo"):
+                self.settings["board_theme"] = self.wizard_theme_combo.currentText()
+                self.settings["accent_color"] = self.wizard_accent_color
         elif idx == 4:
             key = self.llm_key_input.text().strip()
             if key:
@@ -287,6 +344,11 @@ class SetupWizard(QDialog):
                     "base_url": "https://api.groq.com/openai/v1",
                 })
             cfg.set("llm_profiles", profiles)
+        if "board_theme" in self.settings:
+            cfg.set("board_theme", self.settings["board_theme"])
+        if "accent_color" in self.settings and self.settings["accent_color"] != "#FF9500":
+            cfg.set("accent_color", self.settings["accent_color"])
+            Styles.set_accent_color(self.settings["accent_color"])
         cfg.set("setup_completed", True)
 
     def accepted_data(self) -> dict:

--- a/src/gui/dialogs/shortcut_help_dialog.py
+++ b/src/gui/dialogs/shortcut_help_dialog.py
@@ -58,6 +58,7 @@ class ShortcutHelpDialog(QDialog):
         subtitle.setStyleSheet(f"""
             font-size: 12px;
             color: {Styles.COLOR_TEXT_SECONDARY};
+            background: transparent;
             margin-bottom: 8px;
         """)
         layout.addWidget(subtitle)
@@ -166,6 +167,9 @@ class ShortcutHelpDialog(QDialog):
             QFrame {{
                 background-color: {Styles.COLOR_SURFACE};
                 border-radius: 6px;
+            }}
+            QFrame QLabel {{
+                background: transparent;
             }}
         """)
         

--- a/src/gui/dialogs/wizard/wizard_nav_bar.py
+++ b/src/gui/dialogs/wizard/wizard_nav_bar.py
@@ -21,7 +21,7 @@ class WizardNavBar(QWidget):
         self.dots_layout.setContentsMargins(0, 0, 0, 0)
         self.dots_layout.setSpacing(6)
         self.dot_labels = []
-        for i in range(6):
+        for i in range(7):
             dot = QLabel("o")
             dot.setStyleSheet(
                 f"color: {Styles.COLOR_TEXT_MUTED}; font-size: 10px; background: transparent;"
@@ -69,7 +69,32 @@ class WizardNavBar(QWidget):
         """)
         layout.addWidget(self.next_btn)
 
-    def update(self, index: int, total: int = 6):
+    def refresh_accent(self):
+        self.next_btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {Styles.COLOR_ACCENT};
+                color: white;
+                border: none;
+                border-radius: 6px;
+                padding: 6px 24px;
+                font-size: 13px;
+                font-weight: bold;
+            }}
+            QPushButton:hover {{ background-color: {Styles.COLOR_ACCENT_HOVER}; }}
+        """)
+        self.back_btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {Styles.COLOR_SURFACE_LIGHT};
+                color: {Styles.COLOR_TEXT_PRIMARY};
+                border: 1px solid {Styles.COLOR_BORDER};
+                border-radius: 6px;
+                padding: 6px 18px;
+                font-size: 13px;
+            }}
+            QPushButton:hover {{ border: 1px solid {Styles.COLOR_ACCENT}; }}
+        """)
+
+    def update(self, index: int, total: int = 7):
         for i, dot in enumerate(self.dot_labels):
             if i == index:
                 dot.setStyleSheet(
@@ -93,4 +118,4 @@ class WizardNavBar(QWidget):
         self.next_btn.setText("Finish" if is_last else "Next")
         self.next_btn.setVisible(not is_gatekeeper)
         self.back_btn.setVisible(not is_first and not is_gatekeeper)
-        self.skip_btn.setVisible(index == 4)
+        self.skip_btn.setVisible(index == 5)

--- a/src/gui/dialogs/wizard/wizard_pages.py
+++ b/src/gui/dialogs/wizard/wizard_pages.py
@@ -4,6 +4,7 @@ import subprocess
 from PyQt6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QLabel,
     QPushButton, QLineEdit, QProgressBar, QApplication,
+    QComboBox, QFrame,
 )
 from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtGui import QPixmap, QFont
@@ -113,13 +114,14 @@ def build_profile_page(wizard) -> QWidget:
     layout.setContentsMargins(60, 40, 60, 40)
     layout.setSpacing(6)
 
-    heading = QLabel("Link your accounts")
+    heading = QLabel("Your usernames")
     heading.setFont(QFont("", 16, QFont.Weight.Bold))
     heading.setStyleSheet("background: transparent;")
     layout.addWidget(heading)
 
     helper = QLabel(
-        "Optional. Connect accounts to auto-fetch your games right inside the app."
+        "Optional. Enter your usernames so we can autofill them when you fetch games "
+        "and build your stats over time. We never link or access your accounts."
     )
     helper.setWordWrap(True)
     helper.setStyleSheet(
@@ -134,7 +136,7 @@ def build_profile_page(wizard) -> QWidget:
     wizard.chesscom_input.setPlaceholderText("e.g. magnuscarlsen")
     wizard.chesscom_input.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
     layout.addWidget(wizard.chesscom_input)
-    hint = QLabel("Shows your Chess.com games for quick loading")
+    hint = QLabel("Autofills your Chess.com username when fetching games")
     hint.setStyleSheet(
         f"font-size: 12px; color: {Styles.COLOR_TEXT_MUTED}; background: transparent;"
     )
@@ -147,7 +149,7 @@ def build_profile_page(wizard) -> QWidget:
     wizard.lichess_input.setPlaceholderText("e.g. drnykterstein")
     wizard.lichess_input.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
     layout.addWidget(wizard.lichess_input)
-    hint = QLabel("Shows your Lichess games for quick loading")
+    hint = QLabel("Autofills your Lichess username when fetching games")
     hint.setStyleSheet(
         f"font-size: 12px; color: {Styles.COLOR_TEXT_MUTED}; background: transparent;"
     )
@@ -172,6 +174,87 @@ def build_profile_page(wizard) -> QWidget:
     layout.addStretch()
     page._on_show = lambda: wizard.chesscom_input.setFocus()
     return page
+
+
+def build_appearance_page(wizard) -> QWidget:
+    page = QWidget()
+    page.setStyleSheet(PAGE_BG)
+    layout = QVBoxLayout(page)
+    layout.setContentsMargins(60, 40, 60, 40)
+    layout.setSpacing(8)
+
+    heading = QLabel("Personalize your experience")
+    heading.setFont(QFont("", 16, QFont.Weight.Bold))
+    heading.setStyleSheet("background: transparent;")
+    layout.addWidget(heading)
+
+    helper = QLabel("Choose a board theme and accent color that suits your style.")
+    helper.setWordWrap(True)
+    helper.setStyleSheet(
+        f"font-size: 13px; color: {Styles.COLOR_TEXT_SECONDARY}; margin-bottom: 12px; background: transparent;"
+    )
+    layout.addWidget(helper)
+
+    theme_lbl = QLabel("Board theme")
+    theme_lbl.setStyleSheet("background: transparent;")
+    layout.addWidget(theme_lbl)
+    wizard.wizard_theme_combo = QComboBox()
+    wizard.wizard_theme_combo.addItems(list(Styles.BOARD_THEMES.keys()))
+    wizard.wizard_theme_combo.setCurrentText("Green")
+    wizard.wizard_theme_combo.setStyleSheet(Styles.get_combobox_style())
+    wizard.wizard_theme_combo.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+    layout.addWidget(wizard.wizard_theme_combo)
+
+    accent_lbl = QLabel("Accent color")
+    accent_lbl.setStyleSheet("background: transparent; margin-top: 8px;")
+    layout.addWidget(accent_lbl)
+    wizard.wizard_accent_btn = QPushButton("  Pick accent color")
+    wizard.wizard_accent_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+    wizard.wizard_accent_btn.setStyleSheet(f"""
+        QPushButton {{
+            background-color: {Styles.COLOR_SURFACE_LIGHT};
+            color: {Styles.COLOR_TEXT_PRIMARY};
+            border: 1px solid {Styles.COLOR_BORDER};
+            padding: 8px 16px;
+            border-radius: 6px;
+            font-size: 13px;
+            text-align: left;
+        }}
+        QPushButton:hover {{
+            border: 1px solid {Styles.COLOR_ACCENT};
+        }}
+    """)
+    wizard.wizard_accent_btn.clicked.connect(lambda: _pick_accent_color(wizard))
+    layout.addWidget(wizard.wizard_accent_btn)
+
+    wizard.wizard_accent_color = "#FF9500"
+
+    layout.addStretch()
+    return page
+
+
+def _pick_accent_color(wizard):
+    from PyQt6.QtWidgets import QColorDialog
+    from PyQt6.QtGui import QColor
+    color = QColorDialog.getColor(initial=QColor(wizard.wizard_accent_color), parent=wizard, title="Select Accent Color")
+    if color.isValid():
+        wizard.wizard_accent_color = color.name()
+        Styles.set_accent_color(color.name())
+        wizard.wizard_accent_btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {color.name()};
+                color: white;
+                border: none;
+                padding: 8px 16px;
+                border-radius: 6px;
+                font-size: 13px;
+            }}
+            QPushButton:hover {{
+                background-color: {color.name()}CC;
+            }}
+        """)
+        wizard.wizard_accent_btn.setText(f"  {color.name()}")
+        wizard.refresh_accent()
 
 
 def build_stockfish_page(wizard) -> QWidget:
@@ -252,11 +335,11 @@ def build_llm_page(wizard) -> QWidget:
     lbl = QLabel("Provider:")
     lbl.setStyleSheet("background: transparent;")
     provider_row.addWidget(lbl)
-    provider_label = QLabel("Groq")
-    provider_label.setStyleSheet(
+    wizard.provider_label = QLabel("Groq")
+    wizard.provider_label.setStyleSheet(
         f"font-size: 14px; font-weight: bold; color: {Styles.COLOR_ACCENT}; background: transparent;"
     )
-    provider_row.addWidget(provider_label)
+    provider_row.addWidget(wizard.provider_label)
     provider_row.addStretch()
     layout.addLayout(provider_row)
 
@@ -310,12 +393,12 @@ def build_done_page(wizard) -> QWidget:
     )
     layout.addWidget(wizard.summary_label)
 
-    ready = QLabel("Ready to analyze your games!")
-    ready.setAlignment(Qt.AlignmentFlag.AlignCenter)
-    ready.setStyleSheet(
+    wizard.ready_label = QLabel("Ready to analyze your games!")
+    wizard.ready_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+    wizard.ready_label.setStyleSheet(
         f"font-size: 15px; color: {Styles.COLOR_ACCENT}; font-weight: bold; background: transparent;"
     )
-    layout.addWidget(ready)
+    layout.addWidget(wizard.ready_label)
 
     layout.addStretch()
 

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -22,7 +22,7 @@ from src.backend.analysis.analyzer import Analyzer
 from src.utils.resources import ResourceManager
 from src.utils.logger import logger
 from src.utils.config import ConfigManager
-from src.backend.analysis.engine import EngineManager, resolve_engine_path
+from src.backend.analysis.engine import EngineManager, resolve_engine_path, invalidate_engine_cache
 from src.backend.api.chess_com_api import ChessComAPI
 from src.backend.api.lichess_api import LichessAPI
 from src.gui.styles import Styles
@@ -74,7 +74,7 @@ class MainWindow(QMainWindow):
         self.setup_ui()
         
         # Apply Theme
-        self.setStyleSheet(Styles.get_theme())
+        self.refresh_theme()
 
         # Tour overlay — marks the page seen when the tour finishes/closes
         self.tour_overlay = TourOverlay(
@@ -84,20 +84,29 @@ class MainWindow(QMainWindow):
         )
         self.tour_overlay.hide()
 
-        # Engine status pill + analysis status label — left side of status bar
-        # Note: background + border-radius on QLabel inside QStatusBar renders as a
-        # plain rectangle in Qt — use colored text only for a clean look.
+        # Style the status bar itself — without this, macOS renders a grey
+        # native bounding box behind each addWidget() item.
+        self.statusBar().setStyleSheet(f"""
+            QStatusBar {{
+                background-color: {Styles.COLOR_BACKGROUND};
+                border-top: 1px solid {Styles.COLOR_BORDER};
+            }}
+            QStatusBar QLabel {{
+                background: transparent;
+            }}
+        """)
+
         self._engine_pill = QLabel()
-        self._engine_pill.setStyleSheet("font-size: 12px; font-weight: 600; padding: 0 6px;")
+        self._engine_pill.setStyleSheet("font-size: 12px; font-weight: 600; padding: 0 6px; background: transparent;")
         self.statusBar().addWidget(self._engine_pill)
 
         # Thin separator
         sep = QLabel("│")
-        sep.setStyleSheet(f"color: {Styles.COLOR_BORDER}; padding: 0 4px;")
+        sep.setStyleSheet(f"color: {Styles.COLOR_BORDER}; padding: 0 4px; background: transparent;")
         self.statusBar().addWidget(sep)
 
         self._status_lbl = QLabel("Ready")
-        self._status_lbl.setStyleSheet(f"font-size: 12px; color: {Styles.COLOR_TEXT_SECONDARY};")
+        self._status_lbl.setStyleSheet(f"font-size: 12px; color: {Styles.COLOR_TEXT_SECONDARY}; background: transparent;")
         self.statusBar().addWidget(self._status_lbl)
 
         # Spinner timer for Calculating animation
@@ -486,7 +495,7 @@ class MainWindow(QMainWindow):
         """Update the status label with an icon prefix and matching colour."""
         icon, color = self._STATUS_STYLES.get(kind, ("◎", "#3498db"))
         self._status_lbl.setText(f"{icon}  {message}")
-        self._status_lbl.setStyleSheet(f"font-size: 12px; color: {color};")
+        self._status_lbl.setStyleSheet(f"font-size: 12px; color: {color}; background: transparent;")
 
     # ------------------------------------------------------------------
 
@@ -626,6 +635,10 @@ class MainWindow(QMainWindow):
             elif hasattr(self.history_view, 'game_list_widget'):
                 self.history_view.game_list_widget.refresh_styles()
             
+        # Update tour overlay accent
+        if hasattr(self, 'tour_overlay'):
+            self.tour_overlay.refresh_accent()
+
         # Force update
         self.update()
 
@@ -873,6 +886,9 @@ class MainWindow(QMainWindow):
                 background-color: {Styles.COLOR_BACKGROUND};
                 border-bottom: 1px solid {Styles.COLOR_BORDER};
             }}
+            QFrame QLabel {{
+                background: transparent;
+            }}
         """)
         header_layout = QHBoxLayout(self.analysis_header_bar)
         header_layout.setContentsMargins(40, 12, 40, 12)
@@ -928,7 +944,7 @@ class MainWindow(QMainWindow):
         
         self.game_info_label = QLabel("No Game Loaded")
         self.game_info_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.game_info_label.setStyleSheet(f"font-size: 16px; font-weight: bold; color: {Styles.COLOR_TEXT_PRIMARY}; padding: 5px;")
+        self.game_info_label.setStyleSheet(f"font-size: 16px; font-weight: bold; color: {Styles.COLOR_TEXT_PRIMARY}; padding: 5px; background: transparent;")
         center_layout.addWidget(self.game_info_label)
 
         # Captured pieces: White sits at the BOTTOM of the board view,
@@ -1107,9 +1123,25 @@ class MainWindow(QMainWindow):
                 )
         else:
             logger.warning(f"Engine not found (configured: {self.engine_path})")
-            QMessageBox.warning(self, "Engine Not Found", "Please configure the engine path in Settings.")
-            self.sidebar.set_active(3)
-            self.switch_page(3)
+            from .dialogs.engine_error_dialog import EngineNotFoundDialog
+            dialog = EngineNotFoundDialog(self)
+            if hasattr(self, 'config_manager'):
+                dialog.config_manager = lambda: self.config_manager
+            if dialog.exec() == QDialog.DialogCode.Accepted:
+                new_path = dialog.engine_path()
+                if new_path:
+                    self.config_manager.config["engine_path"] = new_path
+                    self.config_manager.save_config()
+                    self.engine_path = new_path
+                    self.analyzer = Analyzer(
+                        EngineManager(self.engine_path, config_manager=self.config_manager)
+                    )
+                    invalidate_engine_cache()
+                    logger.info(f"Engine path set to {new_path} via error dialog")
+                    self._refresh_engine_status()
+            else:
+                self.sidebar.set_active(3)
+                self.switch_page(3)
             return
 
         logger.info("Starting analysis...")

--- a/src/gui/views/history_view.py
+++ b/src/gui/views/history_view.py
@@ -173,16 +173,17 @@ class HistoryView(QWidget):
         if danger:
             btn.setStyleSheet(f"""
                 QPushButton {{
-                    background-color: transparent;
+                    background-color: {Styles.COLOR_SURFACE_LIGHT};
                     color: {Styles.COLOR_BLUNDER};
-                    border: 1px solid {Styles.COLOR_BLUNDER};
+                    border: 1px solid {Styles.COLOR_BORDER};
                     padding: 8px 16px;
                     border-radius: 6px;
                     font-size: 13px;
                 }}
                 QPushButton:hover {{
-                    background-color: {Styles.COLOR_BLUNDER};
-                    color: white;
+                    background-color: {Styles.COLOR_SURFACE};
+                    color: {Styles.COLOR_BLUNDER};
+                    border-color: {Styles.COLOR_ACCENT};
                 }}
             """)
         else:
@@ -554,16 +555,17 @@ class HistoryView(QWidget):
         if hasattr(self, 'btn_clear'):
             self.btn_clear.setStyleSheet(f"""
                 QPushButton {{
-                    background-color: transparent;
+                    background-color: {Styles.COLOR_SURFACE_LIGHT};
                     color: {Styles.COLOR_BLUNDER};
-                    border: 1px solid {Styles.COLOR_BLUNDER};
+                    border: 1px solid {Styles.COLOR_BORDER};
                     padding: 8px 16px;
                     border-radius: 6px;
                     font-size: 13px;
                 }}
                 QPushButton:hover {{
-                    background-color: {Styles.COLOR_BLUNDER};
-                    color: white;
+                    background-color: {Styles.COLOR_SURFACE};
+                    color: {Styles.COLOR_BLUNDER};
+                    border-color: {Styles.COLOR_ACCENT};
                 }}
             """)
             

--- a/src/gui/views/metrics/ai_coach_card.py
+++ b/src/gui/views/metrics/ai_coach_card.py
@@ -1,7 +1,7 @@
 import os
 import json
 import re
-from PyQt6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QScrollArea, QFrame, QSizePolicy
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QScrollArea, QFrame, QSizePolicy, QDialog
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QPixmap
 from src.gui.views.metrics.base_card import MetricCard
@@ -129,13 +129,22 @@ class AICoachCard(MetricCard):
         btn_retry.clicked.connect(self._generate_insights)
         self.insights_layout.addWidget(btn_retry)
 
-        show_error_dialog(
-            self,
-            "AI Coach Insights Failed",
-            "Could not generate AI insights. See the insight card and "
-            "the details below for the full error.",
-            err_msg,
-        )
+        if "not configured" in err_msg.lower():
+            from ...dialogs.llm_error_dialog import LlmNotConfiguredDialog
+            dlg = LlmNotConfiguredDialog(self)
+            if dlg.exec() == QDialog.DialogCode.Accepted and dlg.wants_configure():
+                window = self.window()
+                if hasattr(window, "sidebar") and hasattr(window, "switch_page"):
+                    window.sidebar.set_active(4)
+                    window.switch_page(4)
+        else:
+            show_error_dialog(
+                self,
+                "AI Coach Insights Failed",
+                "Could not generate AI insights. See the insight card and "
+                "the details below for the full error.",
+                err_msg,
+            )
         
     def _populate_insights(self, insight_text):
         self.current_insights = insight_text

--- a/src/gui/views/settings/api_settings.py
+++ b/src/gui/views/settings/api_settings.py
@@ -121,7 +121,11 @@ class ApiSettings(QGroupBox):
                 min-width: 28px; max-width: 28px;
                 min-height: 28px; max-height: 28px;
             }}
-            QPushButton:hover {{ border-color: {Styles.COLOR_ACCENT}; }}
+            QPushButton:hover {{
+                background-color: {Styles.COLOR_SURFACE};
+                color: {Styles.COLOR_TEXT_PRIMARY};
+                border-color: {Styles.COLOR_ACCENT};
+            }}
         """
 
         # --- Profile selector row ---
@@ -164,10 +168,10 @@ class ApiSettings(QGroupBox):
         pf.setContentsMargins(0, 0, 0, 0)
         pf.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow)
 
-        lbl_pname = QLabel("Name:"); lbl_pname.setStyleSheet(lbl_style)
+        self._lbl_pname = QLabel("Name:"); self._lbl_pname.setStyleSheet(lbl_style)
         self.llm_profile_name = QLineEdit()
         self.llm_profile_name.setStyleSheet(Styles.get_input_style())
-        pf.addRow(lbl_pname, self.llm_profile_name)
+        pf.addRow(self._lbl_pname, self.llm_profile_name)
 
         lbl_prov = QLabel("Provider:"); lbl_prov.setStyleSheet(lbl_style)
         self.llm_provider_combo = QComboBox()
@@ -216,18 +220,18 @@ class ApiSettings(QGroupBox):
         api_layout.addLayout(status_row)
 
         # --- Lichess token ---
-        _div2 = QFrame(); _div2.setFrameShape(QFrame.Shape.HLine)
-        _div2.setStyleSheet(f"color: {Styles.COLOR_BORDER};")
-        api_layout.addWidget(_div2)
+        self._api_div2 = QFrame(); self._api_div2.setFrameShape(QFrame.Shape.HLine)
+        self._api_div2.setStyleSheet(f"color: {Styles.COLOR_BORDER};")
+        api_layout.addWidget(self._api_div2)
 
         lf = QFormLayout(); lf.setSpacing(10); lf.setContentsMargins(0, 0, 0, 0)
         lf.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow)
-        lbl_lichess = QLabel("Lichess API Token:"); lbl_lichess.setStyleSheet(lbl_style)
+        self._lbl_lichess = QLabel("Lichess API Token:"); self._lbl_lichess.setStyleSheet(lbl_style)
         self.lichess_token_input = QLineEdit()
         self.lichess_token_input.setEchoMode(QLineEdit.EchoMode.Password)
         self.lichess_token_input.setText(self.config_manager.get("lichess_token", ""))
         self.lichess_token_input.setStyleSheet(Styles.get_input_style())
-        lf.addRow(lbl_lichess, self.lichess_token_input)
+        lf.addRow(self._lbl_lichess, self.lichess_token_input)
         api_layout.addLayout(lf)
 
         self._reload_profile_combo()
@@ -419,6 +423,20 @@ class ApiSettings(QGroupBox):
         worker.done.connect(_on_done)
         worker.finished.connect(_cleanup)
         worker.start()
+
+    def set_advanced_visible(self, visible):
+        self._lbl_pname.setVisible(visible)
+        self.llm_profile_name.setVisible(visible)
+        self.llm_add_btn.setVisible(visible)
+        self.llm_del_btn.setVisible(visible)
+        self.lbl_llm_url.setVisible(visible)
+        self.llm_url_input.setVisible(visible)
+        self.llm_test_btn.setVisible(visible)
+        self.llm_test_result.setVisible(visible)
+        self.llm_active_label.setVisible(visible)
+        self._api_div2.setVisible(visible)
+        self._lbl_lichess.setVisible(visible)
+        self.lichess_token_input.setVisible(visible)
 
     def refresh_styles(self, combo_style, input_style, default_style, llm_add_style, llm_del_style):
         self.setStyleSheet(Styles.get_group_box_style())

--- a/src/gui/views/settings/appearance_settings.py
+++ b/src/gui/views/settings/appearance_settings.py
@@ -74,8 +74,8 @@ class AppearanceSettings(QGroupBox):
         appearance_layout.addRow(piece_lbl, self.piece_combo)
 
         # Sound Effects Selector
-        sound_lbl = QLabel("Sound Effects:")
-        sound_lbl.setStyleSheet(label_style)
+        self._sound_lbl = QLabel("Sound Effects:")
+        self._sound_lbl.setStyleSheet(label_style)
         
         tick_path = get_resource_path("assets/images/tick.svg").replace("\\", "/")
         self.sound_checkbox = QCheckBox("Enable Sound Effects")
@@ -101,7 +101,7 @@ class AppearanceSettings(QGroupBox):
         self.sound_checkbox.setChecked(self.config_manager.get("sound_enabled", True))
         self.sound_checkbox.stateChanged.connect(self.change_sound_setting)
         
-        appearance_layout.addRow(sound_lbl, self.sound_checkbox)
+        appearance_layout.addRow(self._sound_lbl, self.sound_checkbox)
 
         # Accent Color
         color_lbl = QLabel("Accent Color:")
@@ -129,6 +129,9 @@ class AppearanceSettings(QGroupBox):
 
     def change_sound_setting(self, state):
         self.config_manager.config["sound_enabled"] = self.sound_checkbox.isChecked()
+
+    def set_advanced_visible(self, visible):
+        pass
 
     def refresh_styles(self, combo_style, default_style, sound_cb_style):
         self.setStyleSheet(Styles.get_group_box_style())

--- a/src/gui/views/settings/book_settings.py
+++ b/src/gui/views/settings/book_settings.py
@@ -86,6 +86,13 @@ class BookSettings(QGroupBox):
             
         self.polyglot_validation_label.setVisible(True)
 
+    def reload_from_config(self):
+        self.polyglot_path_input.setText(self.config_manager.get("polyglot_book_path", ""))
+        self.validate_polyglot_path()
+
+    def set_advanced_visible(self, visible):
+        self.setVisible(visible)
+
     def refresh_styles(self, combo_style, input_style, default_style):
         self.setStyleSheet(Styles.get_group_box_style())
         self.polyglot_browse_btn.setStyleSheet(default_style)

--- a/src/gui/views/settings/data_settings.py
+++ b/src/gui/views/settings/data_settings.py
@@ -56,6 +56,9 @@ class DataSettings(QGroupBox):
             
             QMessageBox.information(self, "Success", "All data cleared.")
 
+    def set_advanced_visible(self, visible):
+        self.setVisible(visible)
+
     def refresh_styles(self, default_style, danger_style):
         self.setStyleSheet(Styles.get_group_box_style())
         self.clear_cache_btn.setStyleSheet(default_style)

--- a/src/gui/views/settings/engine_settings.py
+++ b/src/gui/views/settings/engine_settings.py
@@ -9,6 +9,7 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QIntValidator, QDoubleValidator
 from ...styles import Styles
 from .helpers import create_icon_button
+from src.constants import DEFAULT_ANALYSIS_DEPTH, DEFAULT_MULTI_PV, DEFAULT_LIVE_ANALYSIS_TIME, DEFAULT_ENGINE_THREADS, DEFAULT_ENGINE_HASH_MB
 
 class EngineSettings(QGroupBox):
     def __init__(self, config_manager, parent=None):
@@ -111,7 +112,7 @@ class EngineSettings(QGroupBox):
         self.depth_combo = QComboBox()
         depth_values = [str(i) for i in range(10, 26)]
         self.depth_combo.addItems(depth_values)
-        self.depth_combo.setCurrentText(str(self.config_manager.get("analysis_depth", 18)))
+        self.depth_combo.setCurrentText(str(self.config_manager.get("analysis_depth", DEFAULT_ANALYSIS_DEPTH)))
         self.depth_combo.setStyleSheet(combo_style)
         self.depth_combo.currentTextChanged.connect(self.change_analysis_depth)
         depth_lbl, depth_row = _wrap(
@@ -122,60 +123,63 @@ class EngineSettings(QGroupBox):
         # --- Multi-PV (alt lines per move) ---
         self.multi_pv_input = QLineEdit()
         self.multi_pv_input.setValidator(QIntValidator(1, 5, self.multi_pv_input))
-        self.multi_pv_input.setText(str(self.config_manager.get("multi_pv", 1)))
+        self.multi_pv_input.setText(str(self.config_manager.get("multi_pv", DEFAULT_MULTI_PV)))
         self.multi_pv_input.setStyleSheet(input_style)
         self.multi_pv_input.editingFinished.connect(self._on_multi_pv_committed)
-        multi_pv_lbl, multi_pv_row = _wrap(
+        self._multi_pv_lbl, multi_pv_row = _wrap(
             "Multi-PV (alt lines):",
             self.multi_pv_input,
             "(1–5; 1 = best line only, recommended for laptops)",
         )
-        form.addRow(multi_pv_lbl, multi_pv_row)
+        self._multi_pv_row = multi_pv_row
+        form.addRow(self._multi_pv_lbl, multi_pv_row)
 
         # --- Live-Analysis time budget (seconds) ---
         self.live_time_input = QLineEdit()
         self.live_time_input.setValidator(QDoubleValidator(0.5, 10.0, 1, self.live_time_input))
-        self.live_time_input.setText(str(self.config_manager.get("live_analysis_time", 2.0)))
+        self.live_time_input.setText(str(self.config_manager.get("live_analysis_time", DEFAULT_LIVE_ANALYSIS_TIME)))
         self.live_time_input.setStyleSheet(input_style)
         self.live_time_input.editingFinished.connect(self._on_live_time_committed)
-        live_time_lbl, live_time_row = _wrap(
+        self._live_time_lbl, live_time_row = _wrap(
             "Live Analysis Time (s):",
             self.live_time_input,
             "(0.5–10.0; per-position CPU budget for the live panel)",
         )
-        form.addRow(live_time_lbl, live_time_row)
+        self._live_time_row = live_time_row
+        form.addRow(self._live_time_lbl, live_time_row)
 
         # --- Engine Threads ---
         cpu_count = os.cpu_count() or 1
-        default_threads = min(cpu_count, 4)
         max_threads = max(32, cpu_count)
 
         self.threads_input = QLineEdit()
         self.threads_input.setValidator(QIntValidator(1, max_threads, self.threads_input))
         self.threads_input.setText(
-            str(self.config_manager.get("engine_threads", default_threads))
+            str(self.config_manager.get("engine_threads", DEFAULT_ENGINE_THREADS))
         )
         self.threads_input.setStyleSheet(input_style)
         self.threads_input.editingFinished.connect(self._on_threads_committed)
-        threads_lbl, threads_row = _wrap(
+        self._threads_lbl, threads_row = _wrap(
             "Engine Threads:",
             self.threads_input,
-            f"(1–{max_threads} integer; recommended for this CPU: {default_threads})",
+            f"(1–{max_threads} integer; recommended for this CPU: {DEFAULT_ENGINE_THREADS})",
         )
-        form.addRow(threads_lbl, threads_row)
+        self._threads_row = threads_row
+        form.addRow(self._threads_lbl, threads_row)
 
         # --- Engine Hash ---
         self.hash_input = QLineEdit()
         self.hash_input.setValidator(QIntValidator(16, 4096, self.hash_input))
-        self.hash_input.setText(str(self.config_manager.get("engine_hash", 64)))
+        self.hash_input.setText(str(self.config_manager.get("engine_hash", DEFAULT_ENGINE_HASH_MB)))
         self.hash_input.setStyleSheet(input_style)
         self.hash_input.editingFinished.connect(self._on_hash_committed)
-        hash_lbl, hash_row = _wrap(
+        self._hash_lbl, hash_row = _wrap(
             "Engine Hash (MB):",
             self.hash_input,
-            "(16–4096 MB; 256 MB is a good default)",
+            "(16–4096 MB; 128 MB is the default)",
         )
-        form.addRow(hash_lbl, hash_row)
+        self._hash_row = hash_row
+        form.addRow(self._hash_lbl, hash_row)
 
         engine_layout.addLayout(form)
         self.validate_engine_path()
@@ -242,55 +246,55 @@ class EngineSettings(QGroupBox):
     def _on_threads_committed(self):
         raw = self.threads_input.text().strip()
         if not raw:
-            current = self.config_manager.get("engine_threads", min(os.cpu_count() or 1, 4))
+            current = self.config_manager.get("engine_threads", DEFAULT_ENGINE_THREADS)
             self.threads_input.setText(str(current))
             return
         threads, ok = self._validated_threads()
         if not ok:
-            current = self.config_manager.get("engine_threads", 1)
+            current = self.config_manager.get("engine_threads", DEFAULT_ENGINE_THREADS)
             self.threads_input.setText(str(current))
 
     def _on_hash_committed(self):
         raw = self.hash_input.text().strip()
         if not raw:
-            current = self.config_manager.get("engine_hash", 64)
+            current = self.config_manager.get("engine_hash", DEFAULT_ENGINE_HASH_MB)
             self.hash_input.setText(str(current))
             return
         hash_mb, ok = self._validated_hash()
         if not ok:
-            current = self.config_manager.get("engine_hash", 64)
+            current = self.config_manager.get("engine_hash", DEFAULT_ENGINE_HASH_MB)
             self.hash_input.setText(str(current))
 
     def _on_multi_pv_committed(self):
         raw = self.multi_pv_input.text().strip()
         if not raw:
-            current = self.config_manager.get("multi_pv", 1)
+            current = self.config_manager.get("multi_pv", DEFAULT_MULTI_PV)
             self.multi_pv_input.setText(str(current))
             return
         try:
             value = int(raw)
         except ValueError:
-            current = self.config_manager.get("multi_pv", 1)
+            current = self.config_manager.get("multi_pv", DEFAULT_MULTI_PV)
             self.multi_pv_input.setText(str(current))
             return
         if not 1 <= value <= 5:
-            current = self.config_manager.get("multi_pv", 1)
+            current = self.config_manager.get("multi_pv", DEFAULT_MULTI_PV)
             self.multi_pv_input.setText(str(current))
 
     def _on_live_time_committed(self):
         raw = self.live_time_input.text().strip()
         if not raw:
-            current = self.config_manager.get("live_analysis_time", 2.0)
+            current = self.config_manager.get("live_analysis_time", DEFAULT_LIVE_ANALYSIS_TIME)
             self.live_time_input.setText(str(current))
             return
         try:
             value = float(raw)
         except ValueError:
-            current = self.config_manager.get("live_analysis_time", 2.0)
+            current = self.config_manager.get("live_analysis_time", DEFAULT_LIVE_ANALYSIS_TIME)
             self.live_time_input.setText(str(current))
             return
         if not 0.5 <= value <= 10.0:
-            current = self.config_manager.get("live_analysis_time", 2.0)
+            current = self.config_manager.get("live_analysis_time", DEFAULT_LIVE_ANALYSIS_TIME)
             self.live_time_input.setText(str(current))
 
     def browse_engine(self):
@@ -329,6 +333,25 @@ class EngineSettings(QGroupBox):
             )
             return None, False
         return value, True
+
+    def reload_from_config(self):
+        self.path_input.setText(self.config_manager.get("engine_path", ""))
+        self.depth_combo.setCurrentText(str(self.config_manager.get("analysis_depth", DEFAULT_ANALYSIS_DEPTH)))
+        self.multi_pv_input.setText(str(self.config_manager.get("multi_pv", DEFAULT_MULTI_PV)))
+        self.live_time_input.setText(str(self.config_manager.get("live_analysis_time", DEFAULT_LIVE_ANALYSIS_TIME)))
+        self.threads_input.setText(str(self.config_manager.get("engine_threads", DEFAULT_ENGINE_THREADS)))
+        self.hash_input.setText(str(self.config_manager.get("engine_hash", DEFAULT_ENGINE_HASH_MB)))
+        self.validate_engine_path()
+
+    def set_advanced_visible(self, visible):
+        self._multi_pv_lbl.setVisible(visible)
+        self._multi_pv_row.setVisible(visible)
+        self._live_time_lbl.setVisible(visible)
+        self._live_time_row.setVisible(visible)
+        self._threads_lbl.setVisible(visible)
+        self._threads_row.setVisible(visible)
+        self._hash_lbl.setVisible(visible)
+        self._hash_row.setVisible(visible)
 
     def refresh_styles(self, combo_style, input_style, default_style):
         self.setStyleSheet(Styles.get_group_box_style())

--- a/src/gui/views/settings/helpers.py
+++ b/src/gui/views/settings/helpers.py
@@ -28,7 +28,7 @@ def create_icon_button(text, icon_name, callback, parent=None, danger=False, pri
     if danger:
         btn.setStyleSheet(f"""
             QPushButton {{
-                background-color: transparent;
+                background-color: {Styles.COLOR_BACKGROUND};
                 color: {Styles.COLOR_BLUNDER};
                 border: 1px solid {Styles.COLOR_BLUNDER};
                 padding: 8px 16px;

--- a/src/gui/views/settings/links_settings.py
+++ b/src/gui/views/settings/links_settings.py
@@ -67,6 +67,9 @@ class LinksSettings(QGroupBox):
             if HAS_QTAWESOME:
                 self.update_btn.setIcon(qta.icon("fa5s.sync-alt", color=Styles.COLOR_TEXT_SECONDARY))
 
+    def set_advanced_visible(self, visible):
+        pass
+
     def refresh_styles(self, default_style):
         self.setStyleSheet(Styles.get_group_box_style())
         self.website_btn.setStyleSheet(default_style)

--- a/src/gui/views/settings/player_settings.py
+++ b/src/gui/views/settings/player_settings.py
@@ -41,12 +41,21 @@ class PlayerSettings(QGroupBox):
         self.games_limit_input.setPlaceholderText("Number of games to fetch (1-30)")
         self.games_limit_input.setStyleSheet(Styles.get_input_style())
         
-        lbl_games_limit = QLabel("Games Fetch Limit:")
-        lbl_games_limit.setStyleSheet(f"color: {Styles.COLOR_TEXT_PRIMARY}; font-size: 13px; background: transparent;")
+        self._lbl_games_limit = QLabel("Games Fetch Limit:")
+        self._lbl_games_limit.setStyleSheet(f"color: {Styles.COLOR_TEXT_PRIMARY}; font-size: 13px; background: transparent;")
 
         username_layout.addRow(lbl_chesscom, self.chesscom_input)
         username_layout.addRow(lbl_lichess_user, self.lichess_input)
-        username_layout.addRow(lbl_games_limit, self.games_limit_input)
+        username_layout.addRow(self._lbl_games_limit, self.games_limit_input)
+
+    def reload_from_config(self):
+        self.chesscom_input.setText(self.config_manager.get("chesscom_username", ""))
+        self.lichess_input.setText(self.config_manager.get("lichess_username", ""))
+        self.games_limit_input.setText(str(self.config_manager.get("api_games_limit", 20)))
+
+    def set_advanced_visible(self, visible):
+        self._lbl_games_limit.setVisible(visible)
+        self.games_limit_input.setVisible(visible)
 
     def refresh_styles(self, input_style, full_input_style):
         self.setStyleSheet(Styles.get_group_box_style())

--- a/src/gui/views/settings_view.py
+++ b/src/gui/views/settings_view.py
@@ -9,6 +9,7 @@ from src.gui.styles import Styles
 from src.utils.path_utils import get_resource_path
 from src.gui.components import MasonryLayout
 from src.utils.config import ConfigManager
+from src.constants import DEFAULT_MULTI_PV, DEFAULT_LIVE_ANALYSIS_TIME
 
 from .settings import (
     EngineSettings,
@@ -60,6 +61,12 @@ class SettingsView(QWidget):
         header_layout.addWidget(header_lbl)
         
         header_layout.addStretch()
+        
+        # Mode toggle
+        self._mode = self.config_manager.get("settings_mode", "basic")
+        self.mode_toggle_btn = self._create_mode_toggle()
+        header_layout.addWidget(self.mode_toggle_btn)
+        header_layout.addSpacing(12)
         
         # Create Save settings button
         self.save_settings_btn = self._create_save_button()
@@ -138,6 +145,18 @@ class SettingsView(QWidget):
         self.feedback_btn = self.links_settings.feedback_btn
         self.update_btn = self.links_settings.update_btn
 
+        self._apply_mode()
+
+    def reload_from_config(self):
+        self.config_manager.reload_config()
+        self.engine_settings.reload_from_config()
+        self.book_settings.reload_from_config()
+        self.player_settings.reload_from_config()
+        self.api_settings._reload_profile_combo()
+        self.api_settings.lichess_token_input.setText(self.config_manager.get("lichess_token", ""))
+        self.appearance_settings.theme_combo.setCurrentText(self.config_manager.get("board_theme", "Green"))
+        self.api_settings._update_active_label()
+
     def _create_save_button(self):
         btn = QMessageBox.QPushButton(f"  Save Settings") if hasattr(QMessageBox, 'QPushButton') else None
         # fallback to standard QPushButton
@@ -170,6 +189,57 @@ class SettingsView(QWidget):
         window = self.window()
         if hasattr(window, "refresh_theme"):
             window.refresh_theme()
+
+    def _create_mode_toggle(self):
+        from PyQt6.QtWidgets import QPushButton
+        from PyQt6.QtCore import Qt
+        btn = QPushButton()
+        btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        btn.clicked.connect(self._toggle_mode)
+        self._update_mode_toggle_text(btn)
+        btn.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {Styles.COLOR_SURFACE_LIGHT};
+                color: {Styles.COLOR_TEXT_SECONDARY};
+                border: 1px solid {Styles.COLOR_BORDER};
+                padding: 8px 16px;
+                border-radius: 6px;
+                font-size: 12px;
+                font-weight: 500;
+            }}
+            QPushButton:hover {{
+                background-color: {Styles.COLOR_SURFACE};
+                color: {Styles.COLOR_ACCENT};
+                border-color: {Styles.COLOR_ACCENT};
+            }}
+        """)
+        return btn
+
+    def _update_mode_toggle_text(self, btn=None):
+        b = btn or self.mode_toggle_btn
+        b.setText("  Advanced Settings" if self._mode == "basic" else "  Basic Settings")
+        if HAS_QTAWESOME:
+            icon_name = "fa5s.cog" if self._mode == "basic" else "fa5s.chevron-left"
+            b.setIcon(qta.icon(icon_name, color=Styles.COLOR_TEXT_SECONDARY))
+
+    def _toggle_mode(self):
+        self._mode = "advanced" if self._mode == "basic" else "basic"
+        self._apply_mode()
+        self._update_mode_toggle_text()
+        self.config_manager.config["settings_mode"] = self._mode
+        self.config_manager.save_config()
+
+    def _apply_mode(self):
+        is_advanced = self._mode == "advanced"
+        is_basic = not is_advanced
+
+        self.engine_settings.set_advanced_visible(is_advanced)
+        self.book_settings.set_advanced_visible(is_advanced)
+        self.api_settings.set_advanced_visible(is_advanced)
+        self.player_settings.set_advanced_visible(is_advanced)
+        self.appearance_settings.set_advanced_visible(is_advanced)
+        self.data_settings.set_advanced_visible(is_advanced)
+        self.links_settings.set_advanced_visible(is_advanced)
 
     def save_all_settings(self):
         """Save every setting in the app at once."""
@@ -247,12 +317,12 @@ class SettingsView(QWidget):
         try:
             self.config_manager.config["multi_pv"] = int(self.engine_settings.multi_pv_input.text().strip())
         except ValueError:
-            self.config_manager.config["multi_pv"] = 1
+            self.config_manager.config["multi_pv"] = DEFAULT_MULTI_PV
             
         try:
             self.config_manager.config["live_analysis_time"] = float(self.engine_settings.live_time_input.text().strip())
         except ValueError:
-            self.config_manager.config["live_analysis_time"] = 2.0
+            self.config_manager.config["live_analysis_time"] = DEFAULT_LIVE_ANALYSIS_TIME
 
         self.config_manager.config["lichess_token"] = self.api_settings.lichess_token_input.text().strip()
         self.config_manager.config["chesscom_username"] = chesscom
@@ -366,16 +436,17 @@ class SettingsView(QWidget):
 
         danger_style = f"""
             QPushButton {{
-                background-color: transparent;
+                background-color: {Styles.COLOR_SURFACE_LIGHT};
                 color: {Styles.COLOR_BLUNDER};
-                border: 1px solid {Styles.COLOR_BLUNDER};
+                border: 1px solid {Styles.COLOR_BORDER};
                 padding: 8px 16px;
                 border-radius: 6px;
                 font-size: 13px;
             }}
             QPushButton:hover {{
-                background-color: {Styles.COLOR_BLUNDER};
-                color: white;
+                background-color: {Styles.COLOR_SURFACE};
+                color: {Styles.COLOR_BLUNDER};
+                border-color: {Styles.COLOR_ACCENT};
             }}
         """
 
@@ -389,7 +460,11 @@ class SettingsView(QWidget):
                 min-width: 28px; max-width: 28px;
                 min-height: 28px; max-height: 28px;
             }}
-            QPushButton:hover {{ border-color: {Styles.COLOR_ACCENT}; }}
+            QPushButton:hover {{
+                background-color: {Styles.COLOR_SURFACE};
+                color: {Styles.COLOR_TEXT_PRIMARY};
+                border-color: {Styles.COLOR_ACCENT};
+            }}
         """
 
         llm_del_style = f"""
@@ -402,7 +477,11 @@ class SettingsView(QWidget):
                 min-width: 28px; max-width: 28px;
                 min-height: 28px; max-height: 28px;
             }}
-            QPushButton:hover {{ border-color: {Styles.COLOR_ACCENT}; }}
+            QPushButton:hover {{
+                background-color: {Styles.COLOR_SURFACE};
+                color: {Styles.COLOR_BLUNDER};
+                border-color: {Styles.COLOR_ACCENT};
+            }}
         """
 
         combo_style = Styles.get_combobox_style()

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -2,6 +2,7 @@ import json
 import os
 from .logger import logger
 from .path_utils import get_app_path, get_user_data_dir
+from src.constants import DEFAULT_ANALYSIS_DEPTH, DEFAULT_MULTI_PV, DEFAULT_LIVE_ANALYSIS_TIME
 
 class ConfigManager:
     CONFIG_FILE = "config.json"
@@ -17,7 +18,7 @@ class ConfigManager:
         #   name, provider, api_key, model, base_url
         "llm_profiles": [],
         "llm_active_profile": "",
-        "analysis_depth": 18,
+        "analysis_depth": DEFAULT_ANALYSIS_DEPTH,
         "api_games_limit": 20,
         # Engine footprint controls (see issue #5).  multi_pv and
         # live_analysis_time are the new user-tunable knobs; we seed
@@ -32,8 +33,8 @@ class ConfigManager:
         # module-level constants when those keys are missing — adding
         # them here as `None` would break that fallback (a stored None
         # wins over a `.get(key, default)` fallback).
-        "multi_pv": 1,
-        "live_analysis_time": 2.0,
+        "multi_pv": DEFAULT_MULTI_PV,
+        "live_analysis_time": DEFAULT_LIVE_ANALYSIS_TIME,
         # Last known main window geometry (x, y, width, height).
         # Any field may be None, meaning "use Qt's default for that dimension".
         "window_state": {"x": None, "y": None, "width": None, "height": None},

--- a/tests/backend/test_engine.py
+++ b/tests/backend/test_engine.py
@@ -1,9 +1,8 @@
 import sys
 import pytest
+from src.constants import DEFAULT_ENGINE_THREADS, DEFAULT_ENGINE_HASH_MB
 from src.backend.analysis.engine import (
     EngineManager,
-    DEFAULT_THREADS,
-    DEFAULT_HASH_MB,
     engine_options,
     options_from_config,
     resolve_engine_path,
@@ -36,8 +35,8 @@ def test_engine_options_builds_uci_dict():
 def test_options_from_config_without_manager_uses_defaults():
     """Without a ConfigManager we get the module-level defaults."""
     opts = options_from_config(None)
-    assert opts["Threads"] == DEFAULT_THREADS
-    assert opts["Hash"] == DEFAULT_HASH_MB
+    assert opts["Threads"] == DEFAULT_ENGINE_THREADS
+    assert opts["Hash"] == DEFAULT_ENGINE_HASH_MB
 
 
 def test_apply_settings_runs_on_running_engine(mocker):

--- a/tests/backend/test_issue5_overheat_fix.py
+++ b/tests/backend/test_issue5_overheat_fix.py
@@ -17,27 +17,24 @@ import pytest
 
 
 # =====================================================================
-# Module-level defaults (engine.py)
+# Module-level defaults (src/constants.py)
 # =====================================================================
 def test_default_threads_capped_for_laptops():
-    """Engine must never default to more than 4 threads."""
-    from src.backend.analysis.engine import DEFAULT_THREADS
-    assert isinstance(DEFAULT_THREADS, int)
-    assert DEFAULT_THREADS >= 1
-    # The cap is the whole point of the fix; on any sensible machine
-    # this means we never default to 8+ threads and fry a fanless CPU.
-    assert DEFAULT_THREADS <= 4, (
-        f"DEFAULT_THREADS={DEFAULT_THREADS} is too high; "
-        "issue #5 capped this at 4 to protect fanless laptops."
+    """Engine must default to 1 thread."""
+    from src.constants import DEFAULT_ENGINE_THREADS
+    assert isinstance(DEFAULT_ENGINE_THREADS, int)
+    assert DEFAULT_ENGINE_THREADS >= 1
+    assert DEFAULT_ENGINE_THREADS == 1, (
+        f"DEFAULT_ENGINE_THREADS={DEFAULT_ENGINE_THREADS}; expected 1."
     )
 
 
 def test_default_hash_is_conservative():
-    """Engine must default to a small hash table (64 MB)."""
-    from src.backend.analysis.engine import DEFAULT_HASH_MB
-    assert isinstance(DEFAULT_HASH_MB, int)
-    assert DEFAULT_HASH_MB == 64, (
-        f"DEFAULT_HASH_MB={DEFAULT_HASH_MB}; expected 64 (issue #5)."
+    """Engine must default to 128 MB hash."""
+    from src.constants import DEFAULT_ENGINE_HASH_MB
+    assert isinstance(DEFAULT_ENGINE_HASH_MB, int)
+    assert DEFAULT_ENGINE_HASH_MB == 128, (
+        f"DEFAULT_ENGINE_HASH_MB={DEFAULT_ENGINE_HASH_MB}; expected 128."
     )
 
 
@@ -51,14 +48,12 @@ def test_engine_options_passthrough():
 # Multi-PV defaults flow through ConfigManager
 # =====================================================================
 def test_config_defaults_include_multi_pv_and_live_time(tmp_path, monkeypatch):
-    """A fresh install must seed multi_pv=1 and live_analysis_time=2.0.
+    """A fresh install must seed multi_pv=2 and live_analysis_time=0.5.
 
     These are the user-facing toggles that fix the overheating bug;
     they must be present in DEFAULT_CONFIG so a brand-new config.json
     is created with safe values.
     """
-    # Redirect the user-data dir into a temp dir so we don't trample
-    # the real config (and so this test is hermetic).
     monkeypatch.setattr(
         "src.utils.path_utils.get_user_data_dir", lambda: str(tmp_path)
     )
@@ -69,33 +64,22 @@ def test_config_defaults_include_multi_pv_and_live_time(tmp_path, monkeypatch):
     ConfigManager._shared_config = None
     ConfigManager._shared_config_path = None
     cm = ConfigManager()
-    assert cm.get("multi_pv", None) == 1
-    assert cm.get("live_analysis_time", None) == 2.0
+    assert cm.get("multi_pv", None) == 2
+    assert cm.get("live_analysis_time", None) == 0.5
 
 
 def test_config_loaded_multi_pv_is_consumed_by_analyzer(monkeypatch, tmp_path):
-    """Analyzer's effective multi_pv must follow the config, not a hard 3.
-
-    We also redirect the user-data dir to a temp dir (and the ConfigManager
-    class to a fake, **in the analyzer module's namespace**, since the
-    class is already imported there at module load time) so the cache /
-    history / book managers don't trample the real on-disk state and
-    don't race with sibling tests that also patch get_user_data_dir.
-    """
+    """Analyzer's effective multi_pv must follow the config, not a hard 3."""
     monkeypatch.setattr(
         "src.utils.path_utils.get_user_data_dir", lambda: str(tmp_path)
     )
     monkeypatch.setattr(
         "src.utils.config.get_user_data_dir", lambda: str(tmp_path)
     )
-    # Build a fake manager that returns whatever we ask for.
     class FakeCM:
         def get(self, key, default=None):
             data = {"analysis_depth": 18, "multi_pv": 2, "live_analysis_time": 1.5}
             return data.get(key, default)
-    # Patch BOTH the source module and the analyzer's already-imported
-    # reference; otherwise the analyzer will see the real ConfigManager
-    # and hit the real on-disk config.
     from src.utils import config as cfg_mod
     from src.backend.analysis import analyzer as analyzer_mod
     monkeypatch.setattr(cfg_mod, "ConfigManager", FakeCM)
@@ -116,18 +100,15 @@ def test_config_loaded_multi_pv_is_consumed_by_analyzer(monkeypatch, tmp_path):
 # LiveAnalysisWorker — finite CPU budget per position
 # =====================================================================
 def test_live_worker_defaults_when_no_config(mocker):
-    """Without a config_manager the worker must use 2.0s / 1 PV.
-
-    The old behaviour was `Limit(depth=None), multipv=3` (infinite,
-    3 PVs); the fix is a finite time budget and 1 PV by default.
-    """
-    # Patch the engine so SimpleEngine.popen_uci is never actually called
+    """Without a config_manager the worker must use 0.5s / 2 PV."""
     mocker.patch("chess.engine.SimpleEngine.popen_uci")
     from src.gui.analysis.live_analysis import LiveAnalysisWorker
     worker = LiveAnalysisWorker("/fake/stockfish")
-    assert worker._live_time() == 2.0
-    assert worker._live_multi_pv() == 1
-    # Sanity: config_manager is None in this path.
+    assert worker._live_time() == 0.5
+    assert worker._live_multi_pv() == 2
+    assert worker._live_depth() == 18
+    assert worker._threads() == 1
+    assert worker._hash() == 128
     assert worker.config_manager is None
 
 
@@ -155,6 +136,5 @@ def test_live_worker_falls_back_safely_on_garbage_config(mocker):
         "multi_pv": 0,  # invalid (< 1) — should be rejected
     }.get(key, default)
     worker = LiveAnalysisWorker("/fake/stockfish", config_manager=cm)
-    # Both fall back to the conservative defaults.
-    assert worker._live_time() == 2.0
-    assert worker._live_multi_pv() == 1
+    assert worker._live_time() == 0.5
+    assert worker._live_multi_pv() == 2

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -19,8 +19,9 @@ class TestConfigManager:
             
             assert manager.get("engine_path") == "stockfish"
             assert manager.get("theme") == "dark"
-            assert manager.get("groq_api_key") == ""
-            assert manager.get("groq_model") == "llama-3.3-70b-versatile"
+            assert manager.get("multi_pv") == 2
+            assert manager.get("live_analysis_time") == 0.5
+            assert manager.get("analysis_depth") == 18
             assert manager.get("api_games_limit") == 20
 
     def test_get_nonexistent_key(self, tmp_path):


### PR DESCRIPTION
## Description

Builds on `feat/onboarding-flow` — simplifies settings with a Basic/Advanced toggle, improves error UX with actionable dialogs, adds appearance customization to the setup wizard, and centralizes engine defaults.

## Changes

### Settings Basic/Advanced toggle
- `settings_view.py` — mode toggle button in header, `_apply_mode()`, `reload_from_config()`
- All settings components — `set_advanced_visible()` hides multi-pv, live-time, threads, hash, API config, games limit, book, and data sections in basic mode
- Sound Effects and Links remain always visible
- Mode persisted to `settings_mode` config key

### Actionable error dialogs
- `EngineNotFoundDialog` — Auto-detect, Download with progress bar, Browse
- `LlmNotConfiguredDialog` — Configure Now / Skip
- Wired into `main_window.py` (start_analysis), `analysis_panel.py`, `ai_coach_card.py`
- `resolve_engine_path()` now writes fallback paths back to config via `_save_fallback_to_config()` so Settings UI stays in sync

### Setup wizard appearance
- **Appearance page** (wizard page 3) — board theme combo + accent color picker
- Wizard now 7 pages total (Gatekeeper, Welcome, Profile, **Appearance**, Stockfish, LLM, Done)
- Nav bar: 7 dots, skip button on LLM page (5)
- `_on_next` on Done page calls `_persist_settings()` before accept
- `Styles.set_accent_color()` integrates with `refresh_accent()` across wizard, nav bar, and tour overlay

### Engine defaults (`src/constants.py`)

| Default | Old | New |
|---------|-----|-----|
| Threads | `min(cpu_count, 4)` | `1` |
| Hash (MB) | `64` | `128` |
| Multi-PV | `1` | `2` |
| Live analysis time (s) | `2.0` | `0.5` |
| Analysis depth | `18` | `18` |

Centralized to `src/constants.py` — all consumers import from one place.

### Other fixes
- Opening book log (`"Opening book populated"`) only fires on actual DB import
- `reload_from_config()` called on `SettingsView` after wizard completes
- UI polish: status bar dark theme, history view button styles, danger button styles, shortcut help dialog transparency
- Wizard text refinements: "Your usernames", "autofill when fetching games", "build your stats"

## Test status
204 passed, 0 failed