### PR TITLE
PR 4: error UX dialogs, PGN parser guard, engine downloader fix

### DIFF
--- a/src/backend/engine/downloader.py
+++ b/src/backend/engine/downloader.py
@@ -14,10 +14,10 @@ import requests
 GITHUB_API = "https://api.github.com/repos/official-stockfish/Stockfish/releases/latest"
 
 PLATFORM_ASSETS: dict[tuple[str, str], str] = {
-    ("darwin", "arm64"):  "stockfish-macos-universal.tar.gz",
-    ("darwin", "x86_64"): "stockfish-macos-universal.tar.gz",
-    ("win32",  "x86_64"): "stockfish-windows-x86-64-universal.zip",
-    ("linux",  "x86_64"): "stockfish-linux-x86-64-universal.tar.gz",
+    ("darwin", "arm64"):  "stockfish-macos-m1-apple-silicon.tar",
+    ("darwin", "x86_64"): "stockfish-macos-x86-64-avx2.tar",
+    ("win32",  "x86_64"): "stockfish-windows-x86-64-avx2.zip",
+    ("linux",  "x86_64"): "stockfish-ubuntu-x86-64-avx2.tar",
 }
 
 
@@ -120,8 +120,10 @@ def download_and_extract(
 
         if url.endswith(".zip"):
             return _extract_zip(tmp_path, dest_dir)
+        elif url.endswith(".tar.gz") or url.endswith(".tgz"):
+            return _extract_tar(tmp_path, dest_dir, "r:gz")
         else:
-            return _extract_tar(tmp_path, dest_dir)
+            return _extract_tar(tmp_path, dest_dir, "r:")
 
     finally:
         if os.path.exists(tmp_path):
@@ -136,9 +138,9 @@ def _extract_zip(archive_path: str, dest_dir: str) -> str:
     return _find_binary(dest_dir)
 
 
-def _extract_tar(archive_path: str, dest_dir: str) -> str:
-    """Extract a .tar.gz archive and return the path to the Stockfish binary."""
-    with tarfile.open(archive_path, "r:gz") as tf:
+def _extract_tar(archive_path: str, dest_dir: str, mode: str = "r:") -> str:
+    """Extract a tar archive and return the path to the Stockfish binary."""
+    with tarfile.open(archive_path, mode) as tf:
         tf.extractall(dest_dir)
 
     return _find_binary(dest_dir)

--- a/src/backend/storage/pgn_parser.py
+++ b/src/backend/storage/pgn_parser.py
@@ -52,6 +52,11 @@ class PGNParser:
                 game = chess.pgn.read_game(f)
                 if game is None:
                     break
+                # Skip games with no moves — garbage input like SQL text
+                # produces a default game object from python-chess but has
+                # no actual moves.
+                if game.next() is None:
+                    continue
                 games.append(PGNParser._convert_to_game_analysis(game))
         return games
 
@@ -63,6 +68,9 @@ class PGNParser:
             game = chess.pgn.read_game(pgn_io)
             if game is None:
                 break
+            # Skip games with no moves (see comment above).
+            if game.next() is None:
+                continue
             games.append(PGNParser._convert_to_game_analysis(game))
         return games
 

--- a/src/gui/analysis/analysis_panel.py
+++ b/src/gui/analysis/analysis_panel.py
@@ -250,17 +250,13 @@ class AnalysisPanel(QWidget):
         if not self.current_game:
             return
         if not self.groq_service.client:
-            QMessageBox.information(
-                self,
-                "LLM Not Configured",
-                "No LLM provider is configured.\n\n"
-                "Go to Settings → API Configuration and choose a provider:\n"
-                "  • Groq (cloud, free tier available)\n"
-                "  • LM Studio (local, no key required)\n"
-                "  • MiniMax (cloud)\n"
-                "  • Custom OpenAI-compatible endpoint\n\n"
-                "Save your settings and try again.",
-            )
+            from ..dialogs.llm_error_dialog import LlmNotConfiguredDialog
+            dlg = LlmNotConfiguredDialog(self)
+            if dlg.exec() == QDialog.DialogCode.Accepted and dlg.wants_configure():
+                window = self.window()
+                if hasattr(window, "sidebar") and hasattr(window, "switch_page"):
+                    window.sidebar.set_active(4)
+                    window.switch_page(4)
             return
         self.btn_generate_summary.setEnabled(False)
         self.loading_overlay.start("Generating AI Summary...")

--- a/src/gui/dialogs/engine_error_dialog.py
+++ b/src/gui/dialogs/engine_error_dialog.py
@@ -57,7 +57,7 @@ class EngineNotFoundDialog(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Engine Not Found")
-        self.setFixedSize(520, 340)
+        self.setFixedSize(520, 420)
         self.setStyleSheet(f"""
             QDialog {{
                 background-color: {Styles.COLOR_BACKGROUND};
@@ -113,6 +113,7 @@ class EngineNotFoundDialog(QDialog):
 
         btn_layout = QVBoxLayout()
         btn_layout.setSpacing(10)
+        btn_layout.setContentsMargins(0, 4, 0, 0)
 
         self._auto_btn = QPushButton("  Auto-detect Stockfish")
         self._auto_btn.setCursor(Qt.CursorShape.PointingHandCursor)
@@ -133,6 +134,8 @@ class EngineNotFoundDialog(QDialog):
         btn_layout.addWidget(self._browse_btn)
 
         layout.addLayout(btn_layout)
+
+        layout.addStretch()
 
         footer = QHBoxLayout()
         footer.addStretch()

--- a/src/gui/dialogs/load_game/chesscom_panel.py
+++ b/src/gui/dialogs/load_game/chesscom_panel.py
@@ -55,6 +55,7 @@ class ChessComPanel(QWidget):
     """
     pgn_ready     = pyqtSignal(str, object)
     pending_cleared = pyqtSignal()
+    navigate_to_settings = pyqtSignal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -178,7 +179,16 @@ class ChessComPanel(QWidget):
         self._reset_input_ui()
 
         if not parsed_games:
-            QMessageBox.warning(self, "No Games", "No games found.")
+            username = self._input_edit.text().strip()
+            msg = QMessageBox(self)
+            msg.setIcon(QMessageBox.Icon.Information)
+            msg.setWindowTitle("No Games Found")
+            msg.setText(f"No games found for {username}.\nMake sure the username is correct.")
+            change_btn = msg.addButton("Change Username", QMessageBox.ButtonRole.ActionRole)
+            msg.addButton("OK", QMessageBox.ButtonRole.RejectRole)
+            msg.exec()
+            if msg.clickedButton() == change_btn:
+                self.navigate_to_settings.emit()
             return
 
         self._parsed_games = parsed_games

--- a/src/gui/dialogs/load_game/lichess_panel.py
+++ b/src/gui/dialogs/load_game/lichess_panel.py
@@ -57,6 +57,7 @@ class LichessPanel(QWidget):
     """
     pgn_ready     = pyqtSignal(str, object)
     pending_cleared = pyqtSignal()
+    navigate_to_settings = pyqtSignal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -174,7 +175,16 @@ class LichessPanel(QWidget):
         self._reset_input_ui()
 
         if not parsed_games:
-            QMessageBox.warning(self, "No Games", "No games found.")
+            username = self._input_edit.text().strip()
+            msg = QMessageBox(self)
+            msg.setIcon(QMessageBox.Icon.Information)
+            msg.setWindowTitle("No Games Found")
+            msg.setText(f"No games found for {username}.\nMake sure the username is correct.")
+            change_btn = msg.addButton("Change Username", QMessageBox.ButtonRole.ActionRole)
+            msg.addButton("OK", QMessageBox.ButtonRole.RejectRole)
+            msg.exec()
+            if msg.clickedButton() == change_btn:
+                self.navigate_to_settings.emit()
             return
 
         self._parsed_games = parsed_games

--- a/src/gui/dialogs/load_game/pgn_file_panel.py
+++ b/src/gui/dialogs/load_game/pgn_file_panel.py
@@ -60,7 +60,15 @@ class PgnFilePanel(QWidget):
         try:
             games = PGNParser.parse_pgn_file(path)
         except Exception as e:
-            QMessageBox.critical(self, "Parse Error", f"Failed to read PGN file:\n{e}")
+            msg = QMessageBox(self)
+            msg.setIcon(QMessageBox.Icon.Warning)
+            msg.setWindowTitle("Could Not Read PGN")
+            msg.setText("Could not read this PGN.\nIt may be empty or corrupted.")
+            try_again = msg.addButton("Try Another File", QMessageBox.ButtonRole.ActionRole)
+            msg.addButton("Cancel", QMessageBox.ButtonRole.RejectRole)
+            msg.exec()
+            if msg.clickedButton() == try_again:
+                self._browse()
             return
 
         if not games:

--- a/src/gui/dialogs/load_game/pgn_text_panel.py
+++ b/src/gui/dialogs/load_game/pgn_text_panel.py
@@ -76,7 +76,16 @@ class PgnTextPanel(QWidget):
         try:
             games = PGNParser.parse_pgn_text(text)
         except Exception as e:
-            QMessageBox.critical(self, "Parse Error", f"Failed to parse PGN text:\n{e}")
+            msg = QMessageBox(self)
+            msg.setIcon(QMessageBox.Icon.Warning)
+            msg.setWindowTitle("Could Not Read PGN")
+            msg.setText("Could not read this PGN.\nIt may be empty or corrupted.")
+            try_again = msg.addButton("Try Again", QMessageBox.ButtonRole.ActionRole)
+            msg.addButton("Cancel", QMessageBox.ButtonRole.RejectRole)
+            msg.exec()
+            if msg.clickedButton() == try_again:
+                self._text_edit.clear()
+                self._text_edit.setFocus()
             return
 
         if not games:

--- a/src/gui/dialogs/load_game_dialog.py
+++ b/src/gui/dialogs/load_game_dialog.py
@@ -45,6 +45,7 @@ class LoadGameDialog(QDialog):
         self.setMinimumSize(680, 480)
 
         self._already_accepted = False
+        self._navigate_to_settings = False
         self._source_btns: list[SourceBtn] = []
         self._setup_ui()
         self._switch_source(initial_source)
@@ -189,6 +190,7 @@ class LoadGameDialog(QDialog):
         self._chesscom_panel.pending_cleared.connect(
             lambda: self._set_pending(None, None)
         )
+        self._chesscom_panel.navigate_to_settings.connect(self._on_navigate_to_settings)
         self.stack.addWidget(self._chesscom_panel)   # index 2
 
         # Lichess
@@ -199,6 +201,7 @@ class LoadGameDialog(QDialog):
         self._lichess_panel.pending_cleared.connect(
             lambda: self._set_pending(None, None)
         )
+        self._lichess_panel.navigate_to_settings.connect(self._on_navigate_to_settings)
         self.stack.addWidget(self._lichess_panel)    # index 3
 
     # ── Source switching ────────────────────────────────────────────────────
@@ -240,6 +243,10 @@ class LoadGameDialog(QDialog):
             self._on_load_clicked()
         else:
             super().keyPressEvent(event)
+
+    def _on_navigate_to_settings(self):
+        self._navigate_to_settings = True
+        self.accept()
 
     def accept(self):
         if not self._already_accepted:

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1011,7 +1011,7 @@ class MainWindow(QMainWindow):
                 self._set_status(status_msg, "success")
             return True
         else:
-            QMessageBox.warning(self, "Error", "Failed to parse game PGN.")
+            QMessageBox.warning(self, "Error", "Could not read this game.\nThe PGN data may be empty or corrupted.")
             return False
 
     def load_game(self, game):
@@ -1202,7 +1202,10 @@ class MainWindow(QMainWindow):
             dialog._pgn_text_panel._parse()
             
         if dialog.exec() == QDialog.DialogCode.Accepted:
-            if dialog._pending_pgn:
+            if dialog._navigate_to_settings:
+                self.sidebar.set_active(4)
+                QTimer.singleShot(0, lambda: self.switch_page(4))
+            elif dialog._pending_pgn:
                 pgn = dialog._pending_pgn
                 sd = dialog._pending_source_data
                 QTimer.singleShot(0, lambda: self._parse_and_load_game(


### PR DESCRIPTION
- Replace plain QMessageBox with LlmNotConfiguredDialog (Configure Now → Settings nav)
- Add navigate_to_settings signal on Chess.com/Lichess panels for "no games found"
- Add "Try Another File" / "Try Again" on PGN parse failure dialogs
- Reject PGN with no moves (game.next() is None) to filter garbage input
- Update Stockfish downloader for sf_18 asset naming
- Increase EngineNotFoundDialog height to 420px