### PR TITLE
feat: custom piece theme import with gradient support and auto-scaling

### DIFF
--- a/src/gui/board/explorer_board_widget.py
+++ b/src/gui/board/explorer_board_widget.py
@@ -34,8 +34,8 @@ class PromotionDialog(QDialog):
         layout.setSpacing(8)
         layout.setContentsMargins(12, 12, 12, 12)
 
-        from src.gui.board.piece_themes import _load_theme_cached
-        pieces_svg = _load_theme_cached("Standard")
+        from src.gui.board.piece_themes import _load_theme_cached, get_current_theme_name
+        pieces_svg = _load_theme_cached(get_current_theme_name())
 
         piece_map = {
             chess.QUEEN:  'Q' if color == chess.WHITE else 'q',
@@ -199,12 +199,12 @@ class ExplorerBoardWidget(BoardWidget):
         self.drag_start_pos = None
 
     def _start_drag_visuals(self):
-        from src.gui.board.piece_themes import _load_theme_cached
+        from src.gui.board.piece_themes import _load_theme_cached, get_current_theme_name
         piece = self.board.piece_at(self.drag_start_sq)
         if not piece:
             return
-            
-        pieces = _load_theme_cached("Standard")
+
+        pieces = _load_theme_cached(get_current_theme_name())
         g_content = pieces.get(piece.symbol(), "")
         svg_str = f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 45 45">{g_content}</svg>'
         

--- a/src/gui/board/piece_themes.py
+++ b/src/gui/board/piece_themes.py
@@ -18,22 +18,20 @@ of this project. See ``assets/pieces/THIRD-PARTY-README.md`` and the
 """
 
 import os
+import re
+import shutil
 import xml.etree.ElementTree as ET
 from functools import lru_cache
 
-from ...utils.path_utils import get_resource_path
+import chess
+
+from ...utils.path_utils import get_resource_path, get_user_data_dir
 from ...utils.logger import logger
 
 
-# Directory that holds the third-party piece SVGs.
-# This path is intentionally outside of the Python source tree so that the
-# MIT-licensed code and the CC BY-SA / GPLv2+ graphics can be licensed
-# independently (see THIRD-PARTY-README.md).
 PIECE_ASSETS_DIR = "assets/pieces"
+USER_THEMES_DIR_NAME = "themes"
 
-# Map of piece symbol (the SAN-style letter used by python-chess) to the
-# SVG file that contains the corresponding graphic. The file content is
-# loaded at runtime by :func:`get_piece_defs`.
 STANDARD_THEME_FILES = {
     "K": "white-king.svg",
     "Q": "white-queen.svg",
@@ -49,33 +47,371 @@ STANDARD_THEME_FILES = {
     "p": "black-pawn.svg",
 }
 
-# All available themes. A theme is a name plus a mapping of piece-symbol
-# to SVG-filename. Additional themes can be added in the future by adding
-# a new subdirectory under ``assets/pieces/<theme-name>/`` with the same
-# 12 file names.
-PIECE_THEMES = {
+SHORT_THEME_FILES = {
+    "K": "wk.svg", "Q": "wq.svg", "R": "wr.svg", "B": "wb.svg",
+    "N": "wn.svg", "P": "wp.svg",
+    "k": "bk.svg", "q": "bq.svg", "r": "br.svg", "b": "bb.svg",
+    "n": "bn.svg", "p": "bp.svg",
+}
+
+PIECE_THEMES: dict[str, dict[str, str]] = {
     "Standard": STANDARD_THEME_FILES,
 }
 
+REQUIRED_THEME_FILES = set(SHORT_THEME_FILES.values())
+_PIECE_TYPE_INDEX = {"p": 1, "n": 2, "b": 3, "r": 4, "q": 5, "k": 6}
 
-def _extract_g_element(svg_path: str) -> str:
+
+def _expected_id(symbol: str) -> str:
+    """Return the SVG element id that board_widget.py references via <use>."""
+    color = "white" if symbol.isupper() else "black"
+    return f"{color}-{chess.PIECE_NAMES[_PIECE_TYPE_INDEX[symbol.lower()]]}"
+
+
+def get_user_themes_dir() -> str:
+    themes_dir = os.path.join(get_user_data_dir(), USER_THEMES_DIR_NAME)
+    os.makedirs(themes_dir, exist_ok=True)
+    return themes_dir
+
+
+def validate_theme_folder(folder_path: str) -> tuple[bool, list[str]]:
+    """Check *folder_path* contains all 12 required SVG files (existence + valid XML)."""
+    errors: list[str] = []
+
+    if not os.path.isdir(folder_path):
+        return False, [f"Folder does not exist: {folder_path}"]
+
+    missing = []
+    for filename in sorted(REQUIRED_THEME_FILES):
+        if not os.path.isfile(os.path.join(folder_path, filename)):
+            missing.append(filename)
+
+    if missing:
+        errors.append(
+            f"Missing {len(missing)} of 12 required files: {', '.join(missing)}"
+        )
+
+    for filename in sorted(REQUIRED_THEME_FILES):
+        file_path = os.path.join(folder_path, filename)
+        if not os.path.isfile(file_path):
+            continue
+        try:
+            _extract_g_element(file_path)
+        except ET.ParseError:
+            errors.append(f"{filename} is not valid XML/SVG")
+        except OSError as e:
+            errors.append(f"{filename}: {e}")
+
+    return len(errors) == 0, errors
+
+
+def import_theme_from_folder(folder_path: str) -> str | None:
+    """Validate, copy, and register a user piece-theme folder. Returns the theme name or None."""
+    is_valid, validation_errors = validate_theme_folder(folder_path)
+    if not is_valid:
+        logger.error(f"Cannot import theme: {validation_errors}")
+        return None
+
+    base_name = os.path.basename(os.path.normpath(folder_path))
+    if not base_name:
+        base_name = "Imported Theme"
+
+    # "Standard" is reserved for the built-in Cburnett set
+    if base_name == "Standard":
+        base_name = "Custom Standard"
+
+    final_name = _unique_theme_name(base_name)
+
+    dest = os.path.join(get_user_themes_dir(), final_name)
+    try:
+        if os.path.exists(dest):
+            shutil.rmtree(dest)
+        shutil.copytree(folder_path, dest)
+    except Exception as e:
+        logger.error(f"Failed to copy theme folder to {dest}: {e}")
+        return None
+
+    scan_user_themes()
+    clear_theme_cache()
+
+    logger.info(f"Imported piece theme {final_name!r} from {folder_path}")
+    return final_name
+
+
+def _unique_theme_name(base_name: str) -> str:
+    """Return *base_name* if unused, otherwise append a counter suffix."""
+    if base_name not in PIECE_THEMES:
+        return base_name
+    counter = 2
+    while f"{base_name} ({counter})" in PIECE_THEMES:
+        counter += 1
+    return f"{base_name} ({counter})"
+
+
+def scan_user_themes() -> None:
+    """Scan the user themes directory and register valid themes."""
+    user_dir = get_user_themes_dir()
+
+    new_themes: dict[str, dict[str, str]] = {"Standard": STANDARD_THEME_FILES}
+
+    if os.path.isdir(user_dir):
+        for entry in sorted(os.listdir(user_dir)):
+            theme_dir = os.path.join(user_dir, entry)
+            if not os.path.isdir(theme_dir):
+                continue
+            if not _has_required_files(theme_dir):
+                logger.debug(f"Skipping incomplete theme folder {entry!r}")
+                continue
+            abs_files: dict[str, str] = {}
+            for symbol, rel_path in SHORT_THEME_FILES.items():
+                abs_files[symbol] = os.path.join(theme_dir, rel_path)
+            new_themes[entry] = abs_files
+
+    PIECE_THEMES.clear()
+    PIECE_THEMES.update(new_themes)
+
+
+def _has_required_files(theme_dir: str) -> bool:
+    """Return True if *theme_dir* contains all 12 required files."""
+    for filename in REQUIRED_THEME_FILES:
+        if not os.path.isfile(os.path.join(theme_dir, filename)):
+            return False
+    return True
+
+
+_RE_NUM = re.compile(r"[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?")
+_RE_URL_REF = re.compile(r"url\(\s*#([^)\s]+)\s*\)")
+
+
+def _prefix_def_refs(elem: ET.Element, prefix: str) -> None:
+    """Prefix ``url(#id)`` and ``href=\"#id\"`` references in *elem* with *prefix*."""
+    for child in elem.iter():
+        for attr in list(child.attrib):
+            val = child.attrib[attr]
+            new_val = _RE_URL_REF.sub(
+                lambda m: f"url(#{prefix}_{m.group(1)})", val
+            )
+            if attr == "href" and val.startswith("#") and len(val) > 1:
+                new_val = f"#{prefix}_{val[1:]}"
+            if new_val != val:
+                child.attrib[attr] = new_val
+
+
+def _parse_path_points(d: str) -> list[tuple[float, float]]:
+    """Extract all (x, y) coordinate pairs from SVG path data."""
+    tokens = re.findall(
+        r"[MLHVCSQTAZmlhvcsqtaz]|-?\d*\.?\d+(?:[eE][-+]?\d+)?", d
+    )
+    points = []
+    i = 0
+    cur_x = cur_y = 0.0
+
+    while i < len(tokens):
+        cmd = tokens[i]
+        i += 1
+        nums = []
+        while i < len(tokens) and re.match(r"^-?\d", tokens[i]):
+            nums.append(float(tokens[i]))
+            i += 1
+
+        j = 0
+        while j < len(nums):
+            if cmd in "Zz":
+                break
+            elif cmd in "Hh":
+                x = nums[j]; j += 1
+                cur_x = cur_x + x if cmd.islower() else x
+                points.append((cur_x, cur_y))
+            elif cmd in "Vv":
+                y = nums[j]; j += 1
+                cur_y = cur_y + y if cmd.islower() else y
+                points.append((cur_x, cur_y))
+            elif cmd in "Aa":
+                if j + 7 <= len(nums):
+                    x = nums[j + 5]; y = nums[j + 6]
+                    j += 7
+                    cur_x = cur_x + x if cmd.islower() else x
+                    cur_y = cur_y + y if cmd.islower() else y
+                    points.append((cur_x, cur_y))
+                else:
+                    break
+            elif cmd in "Cc":
+                if j + 6 <= len(nums):
+                    pts = nums[j:j + 6]; j += 6
+                    if cmd.islower():
+                        pts[0] += cur_x; pts[1] += cur_y
+                        pts[2] += cur_x; pts[3] += cur_y
+                        pts[4] += cur_x; pts[5] += cur_y
+                    points.extend([(pts[0], pts[1]), (pts[2], pts[3]), (pts[4], pts[5])])
+                    cur_x, cur_y = pts[4], pts[5]
+                else:
+                    break
+            elif cmd in "Ss":
+                if j + 4 <= len(nums):
+                    pts = nums[j:j + 4]; j += 4
+                    if cmd.islower():
+                        pts[0] += cur_x; pts[1] += cur_y
+                        pts[2] += cur_x; pts[3] += cur_y
+                    points.extend([(pts[0], pts[1]), (pts[2], pts[3])])
+                    cur_x, cur_y = pts[2], pts[3]
+                else:
+                    break
+            elif cmd in "Qq":
+                if j + 4 <= len(nums):
+                    pts = nums[j:j + 4]; j += 4
+                    if cmd.islower():
+                        pts[0] += cur_x; pts[1] += cur_y
+                        pts[2] += cur_x; pts[3] += cur_y
+                    points.extend([(pts[0], pts[1]), (pts[2], pts[3])])
+                    cur_x, cur_y = pts[2], pts[3]
+                else:
+                    break
+            elif cmd in "Tt":
+                if j + 2 <= len(nums):
+                    x = nums[j]; y = nums[j + 1]; j += 2
+                    if cmd.islower():
+                        x += cur_x; y += cur_y
+                    points.append((x, y))
+                    cur_x, cur_y = x, y
+                else:
+                    break
+            else:  # M, L, m, l
+                if j + 2 <= len(nums):
+                    x = nums[j]; y = nums[j + 1]; j += 2
+                    if cmd.islower():
+                        cur_x += x
+                        cur_y += y
+                    else:
+                        cur_x, cur_y = x, y
+                    points.append((cur_x, cur_y))
+                else:
+                    break
+
+    return points
+
+
+def _parse_points_attr(attr: str) -> list[tuple[float, float]]:
+    """Parse SVG points attribute into coordinate pairs."""
+    nums = list(map(float, _RE_NUM.findall(attr)))
+    return [(nums[i], nums[i + 1]) for i in range(0, len(nums) - 1, 2)]
+
+
+def _strip_ns(elem: ET.Element) -> None:
+    """Strip XML namespace from *elem* tags and attribute keys in-place."""
+    if "}" in elem.tag:
+        elem.tag = elem.tag.split("}", 1)[1]
+    for child in elem.iter():
+        if "}" in child.tag:
+            child.tag = child.tag.split("}", 1)[1]
+        ns_keys = [k for k in child.attrib if "}" in k]
+        for k in ns_keys:
+            child.attrib[k.split("}", 1)[1]] = child.attrib.pop(k)
+
+
+def _get_svg_canvas(root: ET.Element) -> tuple[float, float] | None:
+    """Return (width, height) from viewBox or width/height attributes."""
+    viewbox = root.get("viewBox", "")
+    if viewbox:
+        parts = viewbox.split()
+        if len(parts) == 4:
+            return float(parts[2]), float(parts[3])
+
+    w_str = root.get("width", "")
+    h_str = root.get("height", "")
+    if w_str and h_str:
+        try:
+            return (float(_RE_NUM.search(w_str).group()),
+                    float(_RE_NUM.search(h_str).group()))
+        except (ValueError, AttributeError):
+            pass
+
+    return None
+
+
+@lru_cache(maxsize=128)
+def _get_content_bbox(svg_path: str) -> tuple[float, float, float, float]:
+    """Return (min_x, min_y, max_x, max_y) of all graphical elements in *svg_path*."""
+    tree = ET.parse(svg_path)
+    root = tree.getroot()
+
+    min_x = min_y = float("inf")
+    max_x = max_y = float("-inf")
+
+    def _accumulate(x: float, y: float) -> None:
+        nonlocal min_x, min_y, max_x, max_y
+        if x < min_x: min_x = x
+        if y < min_y: min_y = y
+        if x > max_x: max_x = x
+        if y > max_y: max_y = y
+
+    for elem in root.iter():
+        tag = elem.tag.split("}", 1)[1] if "}" in elem.tag else elem.tag
+
+        t = elem.get("transform", "")
+        m = re.search(r"matrix\(([^)]+)\)", t)
+        if m:
+            values = list(map(float, _RE_NUM.findall(m.group(1))))
+            if len(values) == 6:
+                a, b, c, d_val, e, f = values
+            else:
+                a, b, c, d_val, e, f = 1.0, 0.0, 0.0, 1.0, 0.0, 0.0
+        else:
+            a, b, c, d_val, e, f = 1.0, 0.0, 0.0, 1.0, 0.0, 0.0
+
+        def _apply(x: float, y: float) -> tuple[float, float]:
+            return a * x + c * y + e, b * x + d_val * y + f
+
+        if tag == "path":
+            d = elem.get("d", "")
+            if not d:
+                continue
+            for px, py in _parse_path_points(d):
+                _accumulate(*_apply(px, py))
+
+        elif tag in ("polygon", "polyline"):
+            pts = elem.get("points", "")
+            if not pts:
+                continue
+            for px, py in _parse_points_attr(pts):
+                _accumulate(*_apply(px, py))
+
+        elif tag == "circle":
+            cx = float(elem.get("cx", 0))
+            cy = float(elem.get("cy", 0))
+            r = float(elem.get("r", 0))
+            for px, py in [(cx - r, cy - r), (cx + r, cy + r)]:
+                _accumulate(*_apply(px, py))
+
+        elif tag == "rect":
+            rx = float(elem.get("x", 0))
+            ry = float(elem.get("y", 0))
+            rw = float(elem.get("width", 0))
+            rh = float(elem.get("height", 0))
+            for px, py in [(rx, ry), (rx + rw, ry), (rx, ry + rh), (rx + rw, ry + rh)]:
+                _accumulate(*_apply(px, py))
+
+        elif tag == "ellipse":
+            cx = float(elem.get("cx", 0))
+            cy = float(elem.get("cy", 0))
+            rx = float(elem.get("rx", 0))
+            ry = float(elem.get("ry", 0))
+            for px, py in [(cx - rx, cy - ry), (cx + rx, cy + ry)]:
+                _accumulate(*_apply(px, py))
+
+    if min_x == float("inf"):
+        return 0.0, 0.0, 0.0, 0.0
+
+    return min_x, min_y, max_x, max_y
+
+
+def _extract_g_element(
+    svg_path: str,
+    element_id: str | None = None,
+    target_size: int | None = None,
+    symbol: str | None = None,
+) -> str:
     """
     Read an SVG file and return the inner ``<g>...</g>`` string.
-
-    The renderer in :mod:`board_widget` embeds the pieces as a single
-    ``<defs><g id="...">...</g></defs>`` block, so we strip the wrapping
-    ``<svg>`` element here and return only the ``<g>`` content.
-
-    Args:
-        svg_path: Absolute path to the SVG file on disk.
-
-    Returns:
-        The ``<g>`` element as a string (without the wrapping ``<svg>``).
-
-    Raises:
-        FileNotFoundError: If the SVG file does not exist.
-        ET.ParseError: If the file is not well-formed XML.
-        ValueError: If the SVG does not contain a ``<g>`` element.
     """
     tree = ET.parse(svg_path)
     root = tree.getroot()
@@ -83,95 +419,155 @@ def _extract_g_element(svg_path: str) -> str:
     g_elements = [
         child
         for child in root
-        if child.tag.endswith("}g") or child.tag == "g"
+        if (child.tag.endswith("}g") or child.tag == "g")
     ]
-    if not g_elements:
-        raise ValueError(
-            f"SVG file {svg_path!r} does not contain a <g> element"
-        )
 
-    # We only support single-piece SVG files, so there should be exactly
-    # one <g> inside the wrapping <svg>.
-    if len(g_elements) != 1:
-        raise ValueError(
-            f"SVG file {svg_path!r} contains {len(g_elements)} <g> "
-            f"elements, expected exactly 1"
-        )
+    if len(g_elements) == 1:
+        g_elem = g_elements[0]
+    else:
+        g_elem = ET.Element("g")
+        for child in root:
+            local_tag = child.tag.split("}", 1)[1] if "}" in child.tag else child.tag
+            if local_tag in {"defs", "metadata", "namedview", "title", "script", "style"}:
+                continue
+            g_elem.append(child)
 
-    g_elem = g_elements[0]
+    # Auto-scale to target size
+    if target_size is not None:
+        canvas = _get_svg_canvas(root)
+        if canvas is not None and canvas != (target_size, target_size):
+            bbox = _get_content_bbox(svg_path)
+            bw = bbox[2] - bbox[0]
+            bh = bbox[3] - bbox[1]
+            if bw > 0 and bh > 0:
+                scale = min(target_size / bw, target_size / bh)
+                cx = (bbox[0] + bbox[2]) / 2.0
+                cy = (bbox[1] + bbox[3]) / 2.0
+                tx = target_size / 2.0 - cx * scale
+                ty = target_size / 2.0 - cy * scale
+                wrapper = ET.Element("g", {
+                    "transform": f"translate({tx:.2f},{ty:.2f}) "
+                                 f"scale({scale:.6f})"
+                })
+                if element_id:
+                    wrapper.set("id", element_id)
+                    element_id = None
+                wrapper.append(g_elem)
+                g_elem = wrapper
 
-    # Strip the default XML namespace so the serialised <g> renders as
-    # ``<g>`` (and not ``<ns0:g xmlns:ns0=...>``). The namespace is only
-    # needed at the wrapping <svg> root, which we discard here. Browsers
-    # and QtSvg handle the un-prefixed form correctly, and downstream
-    # code in board_widget.py parses the result with a wrapping <root
-    # xmlns="..."> container that re-introduces the namespace cleanly.
-    if "}" in g_elem.tag:
-        g_elem.tag = "g"
-    for descendant in g_elem.iter():
-        if "}" in descendant.tag:
-            descendant.tag = descendant.tag.split("}", 1)[1]
+    if element_id is not None:
+        g_elem.set("id", element_id)
+
+    _strip_ns(g_elem)
+
+    if symbol:
+        _prefix_def_refs(g_elem, symbol)
 
     return ET.tostring(g_elem, encoding="unicode")
 
 
 @lru_cache(maxsize=16)
 def _load_theme_cached(theme_name: str) -> dict:
-    """
-    Cache-wrapped internal helper to load a theme.
-    
-    This function will raise FileNotFoundError, ET.ParseError, or ValueError
-    on failure. Exceptions are not cached by lru_cache, ensuring that retries
-    will attempt to read from disk again.
-    """
     return _load_theme(theme_name)
 
 
-def _load_theme(theme_name: str) -> dict:
+@lru_cache(maxsize=16)
+def _collect_theme_defs_cached(theme_name: str) -> str:
+    return _collect_theme_defs(theme_name)
+
+
+def _collect_theme_defs(theme_name: str) -> str:
+    """Collect and deduplicate ``<defs>`` children from each SVG in *theme_name*.
+
+    Returns concatenated gradient/filter elements (no wrapping ``<defs>``).
     """
-    Load a piece theme by name and return a ``{piece_symbol: <g>...</g>}``
-    dict.
+    theme_files = PIECE_THEMES.get(theme_name, STANDARD_THEME_FILES)
+    seen_ids: set[str] = set()
+    defs_children: list[str] = []
+
+    for symbol, file_path in theme_files.items():
+        if os.path.isabs(file_path):
+            svg_path = file_path
+        else:
+            svg_path = get_resource_path(
+                os.path.join(PIECE_ASSETS_DIR, file_path)
+            )
+
+        try:
+            tree = ET.parse(svg_path)
+        except (FileNotFoundError, ET.ParseError):
+            continue
+        root = tree.getroot()
+
+        for child in root:
+            tag = child.tag
+            local = tag.split("}", 1)[1] if "}" in tag else tag
+            if local != "defs":
+                continue
+            for def_child in child:
+                def_id = def_child.get("id")
+                prefixed = f"{symbol}_{def_id}" if def_id else None
+                if prefixed and prefixed in seen_ids:
+                    continue
+                if prefixed:
+                    seen_ids.add(prefixed)
+                    def_child.set("id", prefixed)
+                _strip_ns(def_child)
+                if prefixed:
+                    _prefix_def_refs(def_child, symbol)
+                defs_children.append(ET.tostring(def_child, encoding="unicode"))
+
+    if not defs_children:
+        return ""
+
+    return "".join(defs_children) + "\n"
+
+
+def _load_theme(theme_name: str) -> dict:
+    """Return ``{piece_symbol: <g>...</g>}`` for *theme_name*.
 
     Args:
         theme_name: The theme name (a key of :data:`PIECE_THEMES`).
 
     Returns:
-        Dict mapping piece symbol to the corresponding ``<g>`` element
-        string, ready to be embedded inside an SVG ``<defs>`` block.
+        Dict mapping piece symbol to the corresponding ``<g>`` string.
     """
     theme_files = PIECE_THEMES.get(theme_name, STANDARD_THEME_FILES)
-    pieces = {}
-    for symbol, filename in theme_files.items():
-        svg_path = get_resource_path(os.path.join(PIECE_ASSETS_DIR, filename))
-        pieces[symbol] = _extract_g_element(svg_path)
+    pieces: dict[str, str] = {}
+    for symbol, file_path in theme_files.items():
+        if os.path.isabs(file_path):
+            svg_path = file_path
+        else:
+            svg_path = get_resource_path(
+                os.path.join(PIECE_ASSETS_DIR, file_path)
+            )
+        pieces[symbol] = _extract_g_element(
+            svg_path, element_id=_expected_id(symbol), target_size=45,
+            symbol=symbol,
+        )
     return pieces
 
 
 def get_piece_defs(theme_name: str = "Standard") -> str:
-    """
-    Generate SVG defs section with piece definitions for the given theme.
+    """Return SVG pieces for *theme_name* (gradient defs + 12 ``<g>`` elements).
 
-    This loads the piece graphics from ``assets/pieces/`` and caches successful
-    results. If a theme fails to load, it falls back to the Standard theme.
-    If the Standard theme also fails to load, it returns an empty string.
-
-    Args:
-        theme_name: Name of the piece theme to use.
-
-    Returns:
-        SVG string containing the ``<g>`` elements for all 12 pieces,
-        ready to be embedded in a parent ``<svg>`` ``<defs>`` block.
+    Falls back to Standard on failure, then to empty string.
     """
     try:
         pieces = _load_theme_cached(theme_name)
-        return "\n".join(pieces[symbol] for symbol in STANDARD_THEME_FILES)
+        defs_block = _collect_theme_defs_cached(theme_name)
+        return defs_block + "\n".join(
+            pieces[symbol] for symbol in STANDARD_THEME_FILES
+        )
     except Exception as e:
         logger.error(f"Failed to load piece theme {theme_name!r}: {e}")
         if theme_name != "Standard":
             logger.info("Attempting fallback to 'Standard' piece theme.")
             try:
                 pieces = _load_theme_cached("Standard")
-                return "\n".join(pieces[symbol] for symbol in STANDARD_THEME_FILES)
+                return "\n".join(
+                    pieces[symbol] for symbol in STANDARD_THEME_FILES
+                )
             except Exception as fallback_err:
                 logger.error(
                     f"Failed to load fallback 'Standard' piece theme: {fallback_err}"
@@ -180,10 +576,17 @@ def get_piece_defs(theme_name: str = "Standard") -> str:
 
 
 def get_piece_theme_names() -> list:
-    """
-    Get list of available piece theme names.
-
-    Returns:
-        List of theme name strings.
-    """
     return list(PIECE_THEMES.keys())
+
+
+def get_current_theme_name() -> str:
+    from ...utils.config import ConfigManager
+    return ConfigManager().get("piece_theme", "Standard")
+
+
+def clear_theme_cache() -> None:
+    _load_theme_cached.cache_clear()
+    _collect_theme_defs_cached.cache_clear()
+
+
+scan_user_themes()

--- a/src/gui/views/explorer_view.py
+++ b/src/gui/views/explorer_view.py
@@ -647,8 +647,8 @@ class ExplorerView(QWidget):
         if not hasattr(self, '_piece_pixmap_cache'):
             self._piece_pixmap_cache = {}
         if cache_key not in self._piece_pixmap_cache:
-            from src.gui.board.piece_themes import _load_theme_cached
-            pieces_svg = _load_theme_cached("Standard")
+            from src.gui.board.piece_themes import _load_theme_cached, get_current_theme_name
+            pieces_svg = _load_theme_cached(get_current_theme_name())
             g_content = pieces_svg.get(symbol, "")
             if g_content:
                 svg_str = f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 45 45">{g_content}</svg>'

--- a/src/gui/views/settings/appearance_settings.py
+++ b/src/gui/views/settings/appearance_settings.py
@@ -73,6 +73,14 @@ class AppearanceSettings(QGroupBox):
         
         appearance_layout.addRow(piece_lbl, self.piece_combo)
 
+        # Import Theme button (spacer label keeps form alignment)
+        import_lbl = QLabel("")
+        import_lbl.setStyleSheet(label_style)
+        self.import_theme_btn = create_icon_button(
+            "Import Theme...", "fa5s.folder-open", self.import_theme, self
+        )
+        appearance_layout.addRow(import_lbl, self.import_theme_btn)
+
         # Sound Effects Selector
         self._sound_lbl = QLabel("Sound Effects:")
         self._sound_lbl.setStyleSheet(label_style)
@@ -130,6 +138,51 @@ class AppearanceSettings(QGroupBox):
     def change_sound_setting(self, state):
         self.config_manager.config["sound_enabled"] = self.sound_checkbox.isChecked()
 
+    def import_theme(self):
+        from PyQt6.QtWidgets import QFileDialog, QMessageBox
+        from ...board.piece_themes import (
+            get_piece_theme_names,
+            import_theme_from_folder,
+            validate_theme_folder,
+        )
+
+        folder = QFileDialog.getExistingDirectory(
+            self, "Select Piece Theme Folder", "",
+            QFileDialog.Option.ShowDirsOnly,
+        )
+        if not folder:
+            return
+
+        is_valid, errors = validate_theme_folder(folder)
+        if not is_valid:
+            QMessageBox.warning(
+                self, "Invalid Theme",
+                "The selected folder is not a valid piece theme:\n\n"
+                + "\n".join(errors),
+            )
+            return
+
+        theme_name = import_theme_from_folder(folder)
+        if theme_name is None:
+            QMessageBox.critical(
+                self, "Import Failed",
+                "Failed to import the theme. Check the logs for details.",
+            )
+            return
+
+        self.piece_combo.blockSignals(True)
+        self.piece_combo.clear()
+        self.piece_combo.addItems(get_piece_theme_names())
+        self.piece_combo.setCurrentText(theme_name)
+        self.piece_combo.blockSignals(False)
+
+        self.change_piece_theme(theme_name)
+
+        QMessageBox.information(
+            self, "Theme Imported",
+            f"Piece theme '{theme_name}' has been imported and is now active.",
+        )
+
     def set_advanced_visible(self, visible):
         pass
 
@@ -139,3 +192,4 @@ class AppearanceSettings(QGroupBox):
         self.piece_combo.setStyleSheet(combo_style)
         self.sound_checkbox.setStyleSheet(sound_cb_style)
         self.color_btn.setStyleSheet(default_style)
+        self.import_theme_btn.setStyleSheet(default_style)


### PR DESCRIPTION
## Summary

Adds a complete custom piece theme import system — users can import any folder of 12 SVG chess piece images (`wk.svg`, `bp.svg`, etc.) via the appearance settings, and the board will render them correctly regardless of SVG structure.

## Changes

- **Import Theme button** in Appearance Settings: folder picker → validates 12 files exist and are parseable XML → copies to user data dir → auto-selects in theme combo
- **Arbitrary SVG support**: handles 0, 1, or many `<g>` elements; Inkscape/Illustrator exports; no viewBox required; custom gradient IDs
- **Auto-scaling**: content-based bounding box computes scale/translate transforms so pieces fit the 45×45 board square (handles paths, polygons, polylines, circles, rects, ellipses)
- **Gradient dedup & merging**: gradients/filters from all 12 SVGs are merged with symbol-prefixed IDs (`K_linearGradient2507`) to prevent collisions; `url(#)` and `href=#` references are rewritten to match
- **Follows configured theme**: explorer views (promotion dialog, drag visuals, piece icons) now read `piece_theme` from config instead of using hardcoded `"Standard"`