### PR TITLE
Feta/theme enhancement

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,6 +47,7 @@ def main():
     logger.info("Application starting...")
     try:
         app = QApplication(sys.argv)
+        app.setStyle("Fusion")
         
         # Resource paths
         resource_path = get_resource_path("assets")

--- a/src/gui/analysis/analysis_lines_widget.py
+++ b/src/gui/analysis/analysis_lines_widget.py
@@ -25,6 +25,23 @@ class AnalysisLinesWidget(QFrame):
     def __init__(self):
         super().__init__()
         self.setFrameStyle(QFrame.Shape.StyledPanel | QFrame.Shadow.Raised)
+        self._apply_base_style()
+
+        self.layout = QVBoxLayout(self)
+        self.layout.setSpacing(6)
+        self.layout.setContentsMargins(8, 8, 8, 8)
+        
+        # No header layout here anymore
+
+        self._last_multi_pvs = None
+        self._last_turn_color = chess.WHITE
+        self.rows = [] # List of (widget, lbl_depth, lbl_eval, lbl_pv) tuples
+        self.lines_layout = QVBoxLayout()
+        self.lines_layout.setSpacing(6)
+        self.layout.addLayout(self.lines_layout)
+        self.layout.addStretch() # Push lines to top
+
+    def _apply_base_style(self):
         self.setStyleSheet(f"""
             QFrame {{
                 background-color: {Styles.COLOR_SURFACE};
@@ -45,19 +62,11 @@ class AnalysisLinesWidget(QFrame):
                 background: transparent;
             }}
         """)
-        
-        self.layout = QVBoxLayout(self)
-        self.layout.setSpacing(6)
-        self.layout.setContentsMargins(8, 8, 8, 8)
-        
-        # No header layout here anymore
 
-        
-        self.rows = [] # List of (widget, lbl_depth, lbl_eval, lbl_pv) tuples
-        self.lines_layout = QVBoxLayout()
-        self.lines_layout.setSpacing(6)
-        self.layout.addLayout(self.lines_layout)
-        self.layout.addStretch() # Push lines to top
+    def refresh_styles(self):
+        self._apply_base_style()
+        if self._last_multi_pvs is not None:
+            self.update_lines(self._last_multi_pvs, self._last_turn_color)
 
     def clear(self):
         """Clears all analysis lines."""
@@ -93,6 +102,8 @@ class AnalysisLinesWidget(QFrame):
         return " ".join(html_words)
 
     def update_lines(self, multi_pvs, turn_color):
+        self._last_multi_pvs = multi_pvs
+        self._last_turn_color = turn_color
         if not multi_pvs:
             self.clear()
             return

--- a/src/gui/analysis/analysis_panel.py
+++ b/src/gui/analysis/analysis_panel.py
@@ -87,6 +87,7 @@ class AnalysisPanel(QWidget):
         self.eval_layout.addWidget(self.lines_widget, stretch=1)
         
         self.tabs.addTab(self.eval_tab, "Evaluation")
+        self._apply_tabs_style()
         
         # --- Tab 2: Report ---
         self.report_tab = QWidget()
@@ -280,7 +281,41 @@ class AnalysisPanel(QWidget):
                     color: {Styles.COLOR_TEXT_PRIMARY};
                 }}
             """)
+
+        # Refresh the evaluation graph's matplotlib colors
+        if hasattr(self, 'graph_widget'):
+            self.graph_widget.refresh_styles()
+
+        # Refresh checkboxes
+        checkbox_style = f"""
+            QCheckBox {{
+                color: {Styles.COLOR_TEXT_PRIMARY};
+                font-weight: bold;
+                font-size: 13px;
+                background: transparent;
+                border: none;
+            }}
+        """
+        if hasattr(self, 'toggle_checkbox'):
+            self.toggle_checkbox.setStyleSheet(checkbox_style)
+        if hasattr(self, 'cache_checkbox'):
+            self.cache_checkbox.setStyleSheet(checkbox_style)
+
+        # Refresh opening label
+        if hasattr(self, 'opening_label'):
+            self.opening_label.setStyleSheet(
+                f"color: {Styles.COLOR_TEXT_SECONDARY}; font-size: 14px; font-weight: bold; background: transparent;"
+            )
+
+        # Refresh tab widget
+        if hasattr(self, 'tabs'):
+            self._apply_tabs_style()
         
+
+        # Refresh analysis lines widget
+        if hasattr(self, 'lines_widget'):
+            self.lines_widget.refresh_styles()
+
         # Refresh move list panel styles
         if hasattr(self, 'move_list_panel'):
             self.move_list_panel.refresh_styles()
@@ -288,6 +323,34 @@ class AnalysisPanel(QWidget):
         # Refresh summary stats colors if game is loaded
         if self.current_game:
             self._update_summary(self.current_game.summary)
+
+    def _apply_tabs_style(self):
+        """Applies the themed QTabWidget stylesheet."""
+        self.tabs.setStyleSheet(f"""
+            QTabWidget::pane {{
+                border: 1px solid {Styles.COLOR_BORDER};
+                border-radius: 4px;
+                background-color: {Styles.COLOR_SURFACE};
+            }}
+            QTabBar::tab {{
+                background-color: {Styles.COLOR_SURFACE_LIGHT};
+                color: {Styles.COLOR_TEXT_SECONDARY};
+                padding: 6px 14px;
+                border: 1px solid {Styles.COLOR_BORDER};
+                border-bottom: none;
+                border-top-left-radius: 4px;
+                border-top-right-radius: 4px;
+            }}
+            QTabBar::tab:selected {{
+                background-color: {Styles.COLOR_SURFACE};
+                color: {Styles.COLOR_TEXT_PRIMARY};
+                border-bottom: 2px solid {Styles.COLOR_ACCENT};
+            }}
+            QTabBar::tab:hover:!selected {{
+                background-color: {Styles.COLOR_SURFACE};
+                color: {Styles.COLOR_TEXT_PRIMARY};
+            }}
+        """)
 
     def on_summary_generated(self, summary):
         self.loading_overlay.stop()

--- a/src/gui/analysis/captured.py
+++ b/src/gui/analysis/captured.py
@@ -277,6 +277,8 @@ class CapturedPiecesWidget(QFrame):
             """)
         else:
             self.setStyleSheet(f"background: transparent; border: none;")
+    def refresh_styles(self):
+        self._update_container_style()
 
     def _format_ui_clock(self, seconds: float) -> str:
         """Format seconds to a standard premium chess clock format (e.g. 10:00, 1:35, 15.4)."""

--- a/src/gui/analysis/controls.py
+++ b/src/gui/analysis/controls.py
@@ -42,3 +42,10 @@ class GameControlsWidget(QWidget):
         layout.addWidget(self.btn_last)
         layout.addStretch()
         layout.addWidget(self.btn_flip)
+
+    def refresh_styles(self):
+        from src.gui.styles import Styles
+        style = Styles.get_control_button_style()
+        for btn in (self.btn_first, self.btn_prev, self.btn_next,
+                    self.btn_last, self.btn_flip):
+            btn.setStyleSheet(style)

--- a/src/gui/analysis/explorer_move_list.py
+++ b/src/gui/analysis/explorer_move_list.py
@@ -136,6 +136,63 @@ class ExplorerMoveListWidget(QWidget):
 
         self.layout.addLayout(nav_layout)
 
+    def refresh_styles(self):
+        self.table.setStyleSheet(f"""
+            QTableWidget {{
+                background-color: {Styles.COLOR_SURFACE};
+                border: 1px solid {Styles.COLOR_BORDER};
+                border-radius: 8px;
+                gridline-color: transparent;
+                font-size: 14px;
+            }}
+            QTableWidget::item {{
+                padding: 4px 8px;
+                border-bottom: 1px solid {Styles.COLOR_SURFACE_LIGHT};
+            }}
+            QTableWidget::item:hover {{
+                background-color: {Styles.COLOR_SURFACE_LIGHT};
+            }}
+            QTableWidget::item:selected {{
+                background-color: {Styles.COLOR_HIGHLIGHT};
+                color: {Styles.COLOR_TEXT_PRIMARY};
+                border-left: 3px solid {Styles.COLOR_ACCENT};
+            }}
+            QHeaderView::section {{
+                background-color: {Styles.COLOR_SURFACE_LIGHT};
+                color: {Styles.COLOR_TEXT_SECONDARY};
+                padding: 6px;
+                border: none;
+                border-bottom: 2px solid {Styles.COLOR_ACCENT};
+                font-weight: 600;
+                font-size: 13px;
+            }}
+        """)
+        btn_style = f"""
+            QPushButton {{
+                background-color: {Styles.COLOR_SURFACE_LIGHT};
+                color: {Styles.COLOR_TEXT_PRIMARY};
+                border: 1px solid {Styles.COLOR_BORDER};
+                border-radius: 6px;
+                padding: 6px 12px;
+                font-size: 16px;
+                font-weight: bold;
+            }}
+            QPushButton:hover {{
+                background-color: {Styles.COLOR_SURFACE};
+                border: 1px solid {Styles.COLOR_ACCENT};
+            }}
+            QPushButton:pressed {{
+                background-color: {Styles.COLOR_ACCENT};
+                color: white;
+            }}
+            QPushButton:disabled {{
+                color: {Styles.COLOR_TEXT_MUTED};
+                background-color: {Styles.COLOR_SURFACE_LIGHT};
+            }}
+        """
+        for btn in (self.btn_first, self.btn_prev, self.btn_next, self.btn_last):
+            btn.setStyleSheet(btn_style)
+
     def add_move(self, san: str, classification: str = None):
         """Append a new move to the list."""
         # If we are not at the end, truncate the list before adding

--- a/src/gui/analysis/move_cell_widget.py
+++ b/src/gui/analysis/move_cell_widget.py
@@ -51,7 +51,7 @@ class MoveCellWidget(QWidget):
             Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignRight
         )
         self._time_label.setStyleSheet(
-            "color: rgba(255,255,255,140); font-size: 10px;"
+            f"color: {Styles.COLOR_TEXT_MUTED}; font-size: 10px;"
         )
         top_row.addWidget(self._time_label, 0, Qt.AlignmentFlag.AlignVCenter)
 
@@ -62,7 +62,7 @@ class MoveCellWidget(QWidget):
         # need a second custom widget for such a simple thing.
         self._bar = QLabel(self)
         self._bar.setFixedHeight(3)
-        self._bar.setStyleSheet("background: rgba(255,255,255,20); border: none;")
+        self._bar.setStyleSheet(f"background: {Styles.COLOR_SURFACE_LIGHT}; border: none;")
         outer.addWidget(self._bar)
 
         # Track the move index so clicks can re-emit it.
@@ -70,6 +70,8 @@ class MoveCellWidget(QWidget):
         self._san_text: str = ""
         self._classification_color: str = ""
         self._classification_name: str = ""
+        self._last_time_spent: float | None = None
+        self._last_max_seconds: float = 30.0
 
         self.setMouseTracking(True)
         self.setCursor(Qt.CursorShape.PointingHandCursor)
@@ -89,7 +91,7 @@ class MoveCellWidget(QWidget):
             )
         else:
             self._san_label.setStyleSheet(
-                "color: white; font-size: 13px; background: transparent;"
+                f"color: {Styles.COLOR_TEXT_PRIMARY}; font-size: 13px; background: transparent;"
             )
 
         if move.classification in ("Brilliant", "Blunder", "Mistake", "Miss"):
@@ -114,6 +116,9 @@ class MoveCellWidget(QWidget):
             except (TypeError, ValueError):
                 time_spent_val = None
 
+        self._last_time_spent = time_spent_val
+        self._last_max_seconds = float(max_seconds) if max_seconds is not None else 30.0
+
         if time_spent_val is not None:
             if time_spent_val >= 3600:
                 time_str = f"{time_spent_val / 3600:.1f}h"
@@ -125,9 +130,10 @@ class MoveCellWidget(QWidget):
             self._time_label.setText(time_str)
             
             # Use dynamically passed max_seconds for color ratio
-            safe_max = max(1.0, float(max_seconds) if max_seconds is not None else 30.0)
+            safe_max = max(1.0, self._last_max_seconds)
             ratio = min(1.0, time_spent_val / safe_max)
             colour = self._bar_colour(ratio)
+            track = Styles.COLOR_SURFACE_LIGHT
             # Render as left-to-right fill: 100% of the cell width for the
             # coloured portion, plus a faded track for the remainder.
             self._bar.setStyleSheet(
@@ -137,8 +143,8 @@ class MoveCellWidget(QWidget):
                         x1:0, y1:0, x2:1, y2:0,
                         stop:0 {colour},
                         stop:{ratio:.4f} {colour},
-                        stop:{ratio:.4f} rgba(255,255,255,18),
-                        stop:1 rgba(255,255,255,18)
+                        stop:{ratio:.4f} {track},
+                        stop:1 {track}
                     );
                     border: none;
                 }}
@@ -150,11 +156,42 @@ class MoveCellWidget(QWidget):
             )
         else:
             self._time_label.setText("")
-            self._bar.setStyleSheet("background: rgba(255,255,255,12); border: none;")
+            self._bar.setStyleSheet(f"background: {Styles.COLOR_SURFACE_LIGHT}; border: none;")
             self.setToolTip(
                 f"{move.classification + ': ' if move.classification else ''}"
                 f"{move.san}"
             )
+
+    def refresh_styles(self):
+        if self._classification_color:
+            self._san_label.setStyleSheet(
+                f"color: {self._classification_color}; font-size: 13px; background: transparent;"
+            )
+        else:
+            self._san_label.setStyleSheet(
+                f"color: {Styles.COLOR_TEXT_PRIMARY}; font-size: 13px; background: transparent;"
+            )
+        if self._last_time_spent is not None:
+            safe_max = max(1.0, self._last_max_seconds)
+            ratio = min(1.0, self._last_time_spent / safe_max)
+            colour = self._bar_colour(ratio)
+            track = Styles.COLOR_SURFACE_LIGHT
+            self._bar.setStyleSheet(
+                f"""
+                QLabel {{
+                    background: qlineargradient(
+                        x1:0, y1:0, x2:1, y2:0,
+                        stop:0 {colour},
+                        stop:{ratio:.4f} {colour},
+                        stop:{ratio:.4f} {track},
+                        stop:1 {track}
+                    );
+                    border: none;
+                }}
+                """
+            )
+        else:
+            self._bar.setStyleSheet(f"background: {Styles.COLOR_SURFACE_LIGHT}; border: none;")
 
     # ----- helpers ----------------------------------------------------
     def _bar_colour(self, ratio: float) -> str:

--- a/src/gui/analysis/move_list_panel.py
+++ b/src/gui/analysis/move_list_panel.py
@@ -271,6 +271,9 @@ class MoveListPanel(QWidget):
             }}
         """)
 
+        for cell in self._think_bars:
+            cell.refresh_styles()
+
     def on_cell_clicked(self, row, col):
         item = self.table.item(row, col)
         if item:

--- a/src/gui/components/graph_widget.py
+++ b/src/gui/components/graph_widget.py
@@ -99,7 +99,8 @@ class GraphWidget(QWidget):
             self.ax.scatter(scatter_x, scatter_y, c=scatter_colors, s=40, zorder=3, edgecolors='white', linewidths=1)
         
         # Zero line
-        self.ax.axhline(0, color=Styles.COLOR_BORDER, linestyle='--', linewidth=1, zorder=0)
+        zero_line = self.ax.axhline(0, color=Styles.COLOR_BORDER, linestyle='--', linewidth=1, zorder=0)
+        zero_line._is_zero_line = True
         
         # Styling
         self.ax.set_facecolor(Styles.COLOR_SURFACE)
@@ -247,9 +248,39 @@ class GraphWidget(QWidget):
         self.move_clicked.emit(move_index)
 
     def refresh_styles(self):
-        """Re-apply styles with the updated accent color."""
+        """Re-apply all theme-sensitive colors on the matplotlib figure immediately."""
+        # Axes and figure backgrounds
+        self.ax.set_facecolor(Styles.COLOR_SURFACE)
+        self.figure.patch.set_facecolor(Styles.COLOR_SURFACE)
+
+        # Spines
+        self.ax.spines['top'].set_visible(False)
+        self.ax.spines['right'].set_visible(False)
+        self.ax.spines['bottom'].set_color(Styles.COLOR_BORDER)
+        self.ax.spines['left'].set_color(Styles.COLOR_BORDER)
+
+        # Tick label colors
+        self.ax.tick_params(axis='x', colors=Styles.COLOR_TEXT_SECONDARY)
+        self.ax.tick_params(axis='y', colors=Styles.COLOR_TEXT_SECONDARY)
+
+        # Title
+        self.ax.title.set_color(Styles.COLOR_TEXT_PRIMARY)
+
+        # Zero reference line
+        for line in self.ax.lines:
+            if getattr(line, '_is_zero_line', False):
+                line.set_color(Styles.COLOR_BORDER)
+
+        # Current move indicator
         if hasattr(self, 'current_move_line') and self.current_move_line is not None:
             self.current_move_line.set_color(Styles.COLOR_ACCENT)
+
+        # Tooltip annotation
+        if hasattr(self, 'annot') and self.annot is not None:
+            self.annot.get_bbox_patch().set_facecolor(Styles.COLOR_SURFACE_LIGHT)
+            self.annot.get_bbox_patch().set_edgecolor(Styles.COLOR_BORDER)
+            self.annot.set_color(Styles.COLOR_TEXT_PRIMARY)
+
         self.canvas.draw_idle()
 
     def clear(self):

--- a/src/gui/components/sidebar.py
+++ b/src/gui/components/sidebar.py
@@ -1,7 +1,8 @@
-from PyQt6.QtWidgets import QFrame, QVBoxLayout, QPushButton, QLabel, QApplication
-from PyQt6.QtCore import pyqtSignal, Qt, QSize
+from PyQt6.QtWidgets import QFrame, QVBoxLayout, QPushButton, QApplication
+from PyQt6.QtCore import pyqtSignal, Qt, QSize, QPropertyAnimation, QEasingCurve, QTimer, pyqtProperty
 from PyQt6.QtGui import QIcon
 from src.gui.styles import Styles
+from src.gui.theme import ThemeManager
 from src.utils.path_utils import get_resource_path
 import os
 
@@ -11,7 +12,6 @@ try:
 except ImportError:
     HAS_QTAWESOME = False
 
-# Map icon names to qtawesome icons
 QTAWESOME_ICONS = {
     "help.png": "fa5s.question-circle",
     "exit.png": "fa5s.sign-out-alt",
@@ -22,85 +22,172 @@ QTAWESOME_ICONS = {
     "settings.png": "fa5s.cog",
 }
 
+COLLAPSED_WIDTH = 60
+EXPANDED_WIDTH = 200
+
+
 class Sidebar(QFrame):
-    # Signals for navigation
-    page_changed = pyqtSignal(int) # 0: Analyze, 1: Explorer, 2: History, 3: Stats, 4: Settings
+    page_changed = pyqtSignal(int)
 
     def __init__(self):
         super().__init__()
         self.setObjectName("Sidebar")
-        self.setFixedWidth(200) # Increased width for text
-        
+        self._collapsed = False
+        self._animating = False
+        self._sidebar_width = EXPANDED_WIDTH
+
         self.layout = QVBoxLayout(self)
-        self.layout.setContentsMargins(10, 20, 10, 20)
-        self.layout.setSpacing(10)
-        
-        # Navigation Buttons
-        self.btn_analyze = self.create_button("Analyze", "analyze.png", 0)
-        self.btn_explorer = self.create_button("Explorer", "explore.png", 1)
-        self.btn_history = self.create_button("History", "history.png", 2)
-        self.btn_stats = self.create_button("Stats", "stats.png", 3)
-        self.btn_settings = self.create_button("Settings", "settings.png", 4)
-        
-        self.layout.addWidget(self.btn_analyze)
-        self.layout.addWidget(self.btn_explorer)
-        self.layout.addWidget(self.btn_history)
-        self.layout.addWidget(self.btn_stats)
-        self.layout.addWidget(self.btn_settings)
-        
+        self.layout.setContentsMargins(6, 20, 6, 20)
+        self.layout.setSpacing(6)
+
+        nav_specs = [
+            ("Analyze", "analyze.png", 0),
+            ("Explorer", "explorer.png", 1),
+            ("History", "history.png", 2),
+            ("Stats", "stats.png", 3),
+            ("Settings", "settings.png", 4),
+        ]
+
+        self._nav_buttons = []
+        for text, icon_name, idx in nav_specs:
+            btn = self._make_nav_button(text, icon_name, idx)
+            self._nav_buttons.append(btn)
+            self.layout.addWidget(btn)
+
         self.layout.addStretch()
-        
-        # Help Button (for keyboard shortcuts)
-        self.btn_help = self.create_button("Help (F1)", "help.png", -1)
+
+        self.btn_help = self._make_nav_button("Help (F1)", "help.png", -1)
         self.btn_help.clicked.connect(self.show_help)
         self.layout.addWidget(self.btn_help)
-        
-        # Exit Button
-        self.btn_exit = self.create_button("Exit", "exit.png", -1)
+
+        self.btn_collapse = QPushButton()
+        self.btn_collapse.setFixedHeight(40)
+        self.btn_collapse.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.btn_collapse.clicked.connect(self.toggle_collapse)
+        self.layout.addWidget(self.btn_collapse)
+
+        self.btn_exit = self._make_nav_button("Exit", "exit.png", -1)
         self.btn_exit.clicked.connect(QApplication.instance().quit)
         self.layout.addWidget(self.btn_exit)
-        
-        # Style
-        self.setStyleSheet(Styles.get_sidebar_style())
-        
-        # Set initial active
+
+        self.apply_style()
+
+        self._update_labels_and_icons()
+        self.setFixedWidth(EXPANDED_WIDTH)
         self.set_active(0)
 
-    def create_button(self, text, icon_name, index):
-        btn = QPushButton(f"  {text}")
-        btn.setFixedHeight(54)
+    def _get_sidebar_width(self):
+        return self._sidebar_width
+
+    def _set_sidebar_width(self, w):
+        self._sidebar_width = w
+        self.setFixedWidth(int(round(w)))
+
+    sidebar_width = pyqtProperty(float, _get_sidebar_width, _set_sidebar_width)
+
+    def _make_nav_button(self, text: str, icon_name: str, index: int) -> QPushButton:
+        btn = QPushButton(text)
+        btn.setFixedHeight(48)
         btn.setCursor(Qt.CursorShape.PointingHandCursor)
-        
-        # Try to load icon from assets first
-        icon_path = get_resource_path(os.path.join("assets", "icons", icon_name))
-        if os.path.exists(icon_path):
-            btn.setIcon(QIcon(icon_path))
-            btn.setIconSize(QSize(28, 28))
-        elif HAS_QTAWESOME and icon_name in QTAWESOME_ICONS:
-            # Fallback to qtawesome
+        btn.setCheckable(index >= 0)
+
+        if HAS_QTAWESOME and icon_name in QTAWESOME_ICONS:
             btn.setIcon(qta.icon(QTAWESOME_ICONS[icon_name], color=Styles.COLOR_TEXT_SECONDARY))
-            btn.setIconSize(QSize(24, 24))
-            
-        btn.setCheckable(True)
-        
+            btn.setIconSize(QSize(22, 22))
+        else:
+            icon_path = get_resource_path(os.path.join("assets", "icons", icon_name))
+            if os.path.exists(icon_path):
+                btn.setIcon(QIcon(icon_path))
+                btn.setIconSize(QSize(22, 22))
+
         if index >= 0:
-            btn.clicked.connect(lambda: self.handle_click(index))
-            
+            btn.clicked.connect(lambda checked, idx=index: self.handle_click(idx))
+
         return btn
 
+    def apply_style(self):
+        p = ThemeManager.palette()
+        self.setStyleSheet(f"""
+            #Sidebar {{
+                background-color: {p.surface};
+                border-right: 1px solid {p.border};
+            }}
+            QPushButton {{
+                background-color: transparent;
+                border: none;
+                border-radius: 8px;
+                padding: 0px 12px;
+                text-align: left;
+                font-size: 14px;
+                font-weight: 500;
+                color: {p.text_secondary};
+            }}
+            QPushButton:hover {{
+                background-color: {p.surface_light};
+                color: {p.text_primary};
+            }}
+            QPushButton:checked {{
+                background-color: transparent;
+                border-left: 3px solid {p.accent};
+                color: {p.accent};
+                font-weight: 600;
+                border-radius: 0;
+            }}
+        """)
+
+    def _update_labels_and_icons(self):
+        nav_texts = ["Analyze", "Explorer", "History", "Stats", "Settings"]
+        for btn, txt in zip(self._nav_buttons, nav_texts):
+            btn.setText(f"  {txt}" if not self._collapsed else "")
+        self.btn_help.setText("  Help (F1)" if not self._collapsed else "")
+        self.btn_exit.setText("  Exit" if not self._collapsed else "")
+        self._update_collapse_icon()
+
+    def _update_collapse_icon(self):
+        icon_char = "\u00ab" if not self._collapsed else "\u00bb"
+        self.btn_collapse.setText(f"  {icon_char}" if not self._collapsed else icon_char)
+        if HAS_QTAWESOME:
+            self.btn_collapse.setIcon(qta.icon(
+                "fa5s.chevron-left" if not self._collapsed else "fa5s.chevron-right",
+                color=Styles.COLOR_TEXT_SECONDARY,
+            ))
+            self.btn_collapse.setIconSize(QSize(16, 16))
+
     def handle_click(self, index):
-        self.set_active(index)
-        self.page_changed.emit(index)
+        if self._collapsed:
+            self.set_active(index)
+            self.page_changed.emit(index)
+            QTimer.singleShot(200, self.toggle_collapse)
+        else:
+            self.set_active(index)
+            self.page_changed.emit(index)
 
     def set_active(self, index):
-        self.btn_analyze.setChecked(index == 0)
-        self.btn_explorer.setChecked(index == 1)
-        self.btn_history.setChecked(index == 2)
-        self.btn_stats.setChecked(index == 3)
-        self.btn_settings.setChecked(index == 4)
-    
+        for i, btn in enumerate(self._nav_buttons):
+            btn.setChecked(i == index)
+
+    def toggle_collapse(self):
+        if self._animating:
+            return
+        self._animating = True
+        self._collapsed = not self._collapsed
+        target = COLLAPSED_WIDTH if self._collapsed else EXPANDED_WIDTH
+
+        self._update_labels_and_icons()
+
+        self._anim = QPropertyAnimation(self, b"sidebar_width")
+        self._anim.setDuration(200)
+        self._anim.setStartValue(float(self.width()))
+        self._anim.setEndValue(float(target))
+        self._anim.setEasingCurve(QEasingCurve.Type.OutQuad)
+        self._anim.finished.connect(self._on_anim_finished)
+        self._anim.start()
+
+    def _on_anim_finished(self):
+        self._animating = False
+        self.setFixedWidth(int(round(self._sidebar_width)))
+
     def show_help(self):
-        """Show the keyboard shortcuts help dialog."""
         from src.gui.dialogs import ShortcutHelpDialog
         dialog = ShortcutHelpDialog(self)
         dialog.exec()

--- a/src/gui/components/stat_card.py
+++ b/src/gui/components/stat_card.py
@@ -6,6 +6,7 @@ from PyQt6.QtWidgets import QFrame, QVBoxLayout, QHBoxLayout, QLabel
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QPixmap
 from src.gui.styles import Styles
+from src.gui.theme import ThemeManager
 from src.gui.utils.gui_utils import resolve_asset  # Use shared utility
 
 
@@ -95,6 +96,8 @@ class StatCard(QFrame):
             """)
             self.lbl_sub.setWordWrap(True)
             layout.addWidget(self.lbl_sub)
+
+        ThemeManager.apply_elevation(self, elevation=1)
             
     def refresh_styles(self):
         """Re-apply styles with the updated accent color."""
@@ -209,6 +212,8 @@ class SimpleStatCard(QFrame):
         
         layout.addWidget(self.lbl_title)
         layout.addWidget(self.lbl_value)
+
+        ThemeManager.apply_elevation(self, elevation=1)
 
     def refresh_styles(self):
         """Re-apply styles with the updated accent color."""

--- a/src/gui/components/toast.py
+++ b/src/gui/components/toast.py
@@ -1,0 +1,105 @@
+from PyQt6.QtCore import Qt, QTimer, QPropertyAnimation, QEasingCurve
+from PyQt6.QtWidgets import QWidget, QHBoxLayout, QLabel, QGraphicsOpacityEffect
+
+
+class Toast(QWidget):
+    DURATIONS = {
+        "info": 3500,
+        "success": 3000,
+        "warning": 4500,
+        "error": 6000,
+    }
+
+    COLORS = {
+        "info": "#3498db",
+        "success": "#27ae60",
+        "warning": "#e67e22",
+        "error": "#e74c3c",
+    }
+
+    def __init__(self, parent, message, kind="info", duration=None):
+        super().__init__(parent)
+        self._kind = kind
+        self._duration = duration or self.DURATIONS.get(kind, 3500)
+        self._is_dismissing = False
+
+        kind_color = self.COLORS.get(kind, "#3498db")
+        dark_bg = "#2C2C30"
+
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        self.setStyleSheet(f"""
+            Toast {{
+                background-color: {dark_bg};
+                border: 1px solid {kind_color};
+                border-radius: 12px;
+            }}
+        """)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(16, 12, 16, 12)
+        layout.setSpacing(10)
+
+        icon_map = {"info": "\u2139", "success": "\u2713", "warning": "\u26A0", "error": "\u2717"}
+        icon = QLabel(icon_map.get(kind, "\u2139"))
+        icon.setStyleSheet(f"color: {kind_color}; font-size: 16px; font-weight: 700; background: transparent;")
+        icon.setFixedWidth(20)
+        icon.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(icon)
+
+        self._msg = QLabel(message)
+        self._msg.setStyleSheet("color: #F0F0F2; font-size: 14px; font-weight: 500; background: transparent;")
+        self._msg.setWordWrap(True)
+        layout.addWidget(self._msg)
+
+        self.adjustSize()
+        self.setMinimumWidth(280)
+        self.setMaximumWidth(420)
+
+        self._opacity_effect = QGraphicsOpacityEffect(self)
+        self._opacity_effect.setOpacity(0.0)
+        self.setGraphicsEffect(self._opacity_effect)
+
+        self._fade_in = QPropertyAnimation(self._opacity_effect, b"opacity")
+        self._fade_in.setDuration(200)
+        self._fade_in.setStartValue(0.0)
+        self._fade_in.setEndValue(1.0)
+        self._fade_in.setEasingCurve(QEasingCurve.Type.OutCubic)
+
+        parent.installEventFilter(self)
+
+        QTimer.singleShot(self._duration, self._start_dismiss)
+
+    def _start_dismiss(self):
+        if self._is_dismissing:
+            return
+        self._is_dismissing = True
+        self._fade_out = QPropertyAnimation(self._opacity_effect, b"opacity")
+        self._fade_out.setDuration(250)
+        self._fade_out.setStartValue(1.0)
+        self._fade_out.setEndValue(0.0)
+        self._fade_out.setEasingCurve(QEasingCurve.Type.OutQuad)
+        self._fade_out.finished.connect(self.deleteLater)
+        self._fade_out.start()
+
+    def eventFilter(self, obj, event):
+        if obj is self.parent() and event.type() == event.Type.Resize:
+            self._reposition()
+        return super().eventFilter(obj, event)
+
+    def _reposition(self):
+        parent = self.parent()
+        if parent:
+            x = parent.width() - self.width() - 24
+            y = 20
+            self.move(x, y)
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        self._reposition()
+        self._fade_in.start()
+
+    @classmethod
+    def show_message(cls, parent, message, kind="info", duration=None):
+        toast = cls(parent, message, kind, duration)
+        toast.show()
+        return toast

--- a/src/gui/components/transition_stack.py
+++ b/src/gui/components/transition_stack.py
@@ -1,0 +1,57 @@
+from PyQt6.QtCore import QPropertyAnimation, QEasingCurve
+from PyQt6.QtWidgets import QStackedWidget
+from PyQt6.QtWidgets import QGraphicsOpacityEffect
+
+
+class FadedStackedWidget(QStackedWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._current = 0
+
+    def setCurrentIndex(self, index):
+        if index == self._current:
+            return
+
+        current_widget = self.widget(self._current)
+        next_widget = self.widget(index)
+
+        if current_widget is None or next_widget is None:
+            super().setCurrentIndex(index)
+            self._current = index
+            return
+
+        opacity = QGraphicsOpacityEffect(current_widget)
+        current_widget.setGraphicsEffect(opacity)
+        self._fade_out = QPropertyAnimation(opacity, b"opacity")
+        self._fade_out.setDuration(150)
+        self._fade_out.setStartValue(1.0)
+        self._fade_out.setEndValue(0.0)
+        self._fade_out.setEasingCurve(QEasingCurve.Type.OutQuad)
+
+        opacity_in = QGraphicsOpacityEffect(next_widget)
+        next_widget.setGraphicsEffect(opacity_in)
+        opacity_in.setOpacity(0.0)
+
+        self._fade_in = QPropertyAnimation(opacity_in, b"opacity")
+        self._fade_in.setDuration(150)
+        self._fade_in.setStartValue(0.0)
+        self._fade_in.setEndValue(1.0)
+        self._fade_in.setEasingCurve(QEasingCurve.Type.InQuad)
+
+        _parent_set = QStackedWidget.setCurrentIndex
+        _self = self
+        _fade_in = self._fade_in
+
+        def on_fade_out_finished():
+            _parent_set(_self, index)
+            _fade_in.start()
+
+        def on_fade_in_finished():
+            current_widget.setGraphicsEffect(None)
+            next_widget.setGraphicsEffect(None)
+            _self._current = index
+
+        self._fade_out.finished.connect(on_fade_out_finished)
+        self._fade_in.finished.connect(on_fade_in_finished)
+
+        self._fade_out.start()

--- a/src/gui/dialogs/load_game/drop_zone.py
+++ b/src/gui/dialogs/load_game/drop_zone.py
@@ -11,22 +11,27 @@ class DropZone(QLabel):
     file_dropped = pyqtSignal(str)
     clicked       = pyqtSignal()      # for keyboard / click-to-browse
 
-    _STYLE_IDLE = f"""
-        QLabel {{
-            background-color: {Styles.COLOR_SURFACE};
-            border: 2px dashed {Styles.COLOR_BORDER};
-            border-radius: 12px;
-            color: {Styles.COLOR_TEXT_SECONDARY};
-        }}
-    """
-    _STYLE_HOVER = f"""
-        QLabel {{
-            background-color: {Styles.COLOR_ACCENT_SUBTLE};
-            border: 2px dashed {Styles.COLOR_ACCENT};
-            border-radius: 12px;
-            color: {Styles.COLOR_TEXT_PRIMARY};
-        }}
-    """
+    @property
+    def _STYLE_IDLE(self):
+        return f"""
+            QLabel {{
+                background-color: {Styles.COLOR_SURFACE};
+                border: 2px dashed {Styles.COLOR_BORDER};
+                border-radius: 12px;
+                color: {Styles.COLOR_TEXT_SECONDARY};
+            }}
+        """
+
+    @property
+    def _STYLE_HOVER(self):
+        return f"""
+            QLabel {{
+                background-color: {Styles.COLOR_ACCENT_SUBTLE};
+                border: 2px dashed {Styles.COLOR_ACCENT};
+                border-radius: 12px;
+                color: {Styles.COLOR_TEXT_PRIMARY};
+            }}
+        """
 
     def __init__(self, parent=None):
         super().__init__(parent)

--- a/src/gui/dialogs/load_game/source_button.py
+++ b/src/gui/dialogs/load_game/source_button.py
@@ -76,3 +76,6 @@ class SourceBtn(QPushButton):
     def setChecked(self, checked: bool):
         super().setChecked(checked)
         self._apply_style(checked)
+
+    def refresh_styles(self):
+        self._apply_style(self.isChecked())

--- a/src/gui/dialogs/load_game_dialog.py
+++ b/src/gui/dialogs/load_game_dialog.py
@@ -52,6 +52,11 @@ class LoadGameDialog(QDialog):
 
     # ── UI construction ─────────────────────────────────────────────────────
     def _setup_ui(self):
+        from PyQt6.QtCore import Qt as _Qt
+        from src.gui.styles import Styles
+        # Force Qt to honour the background-color on the dialog window itself
+        # (macOS ignores it without this attribute)
+        self.setAttribute(_Qt.WidgetAttribute.WA_StyledBackground, True)
         self.setStyleSheet(f"""
             QDialog {{
                 background-color: {Styles.COLOR_BACKGROUND};

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -4,8 +4,9 @@ from PyQt6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout,
                              QHBoxLayout, QSplitter, QFileDialog, QMenuBar,
                              QStatusBar, QMessageBox, QInputDialog, QDialog,
                              QListWidget, QListWidgetItem, QPushButton, QLineEdit, QLabel, QStackedWidget, QTextEdit, QFrame)
+
 from PyQt6.QtCore import Qt, QThread, pyqtSignal, QTimer
-from PyQt6.QtGui import QAction, QIcon, QShortcut, QKeySequence
+from PyQt6.QtGui import QAction, QIcon, QShortcut, QKeySequence, QPalette, QColor
 from PyQt6.QtWidgets import QMenu
 import shutil
 
@@ -26,6 +27,7 @@ from src.backend.analysis.engine import EngineManager, resolve_engine_path, inva
 from src.backend.api.chess_com_api import ChessComAPI
 from src.backend.api.lichess_api import LichessAPI
 from src.gui.styles import Styles
+from src.gui.theme import ThemeManager
 from src.gui.utils.gui_utils import create_button
 from src.backend.storage.models import MoveAnalysis, GameAnalysis, GameMetadata
 from src.backend.storage.game_history import GameHistoryManager
@@ -33,6 +35,8 @@ from src.utils.path_utils import get_resource_path
 from src.gui.components.loading_widget import LoadingOverlay
 from src.gui.components.tour_manager import TourManager, TourStep
 from src.gui.components.tour_overlay import TourOverlay
+from src.gui.components.transition_stack import FadedStackedWidget
+from src.gui.components.toast import Toast
 
 class MainWindow(QMainWindow):
     def __init__(self):
@@ -63,10 +67,21 @@ class MainWindow(QMainWindow):
         if os.path.exists(icon_path):
             self.setWindowIcon(QIcon(icon_path))
 
-        # Load Configured Theme
+        # Initialize ThemeManager
+        self._theme_manager = ThemeManager(parent=self)
+
+        saved_theme_mode = self.config_manager.get("theme_mode", "system")
+        ThemeManager.set_theme_mode(saved_theme_mode)
+
         saved_accent = self.config_manager.get("accent_color")
-        if saved_accent:
-            Styles.set_accent_color(saved_accent)
+        saved_accent_mode = self.config_manager.get("accent_mode", "system")
+        if saved_accent_mode == "system":
+            ThemeManager.set_accent_mode("system")
+        elif saved_accent:
+            ThemeManager.set_accent(saved_accent)
+
+        self._theme_manager.theme_changed.connect(self._on_theme_changed)
+        self._theme_manager.accent_changed.connect(self._on_accent_changed)
 
         # UI Setup
         self.setup_ui()
@@ -311,7 +326,7 @@ class MainWindow(QMainWindow):
         main_layout.addWidget(self.sidebar)
         
         # Stacked Widget for Pages
-        self.stack = QStackedWidget()
+        self.stack = FadedStackedWidget()
         main_layout.addWidget(self.stack)
         
         # --- Page 0: Analysis View ---
@@ -431,6 +446,19 @@ class MainWindow(QMainWindow):
             self.on_move_selected(-1)
 
     # ------------------------------------------------------------------
+    # Toast notifications
+    # ------------------------------------------------------------------
+
+    def show_toast(self, message: str, kind: str = "info", duration: int | None = None):
+        Toast.show_message(self, message, kind, duration)
+
+    @staticmethod
+    def toast_from_widget(widget, message: str, kind: str = "info", duration: int | None = None):
+        win = widget.window()
+        if hasattr(win, "show_toast"):
+            win.show_toast(message, kind, duration)
+
+    # ------------------------------------------------------------------
     # Status bar helpers
     # ------------------------------------------------------------------
 
@@ -511,7 +539,7 @@ class MainWindow(QMainWindow):
             )
             if hasattr(self, 'move_list_panel'):
                 self.move_list_panel.update_engine_path(new_path)
-            QMessageBox.information(self, "Success", "Engine path updated. Future analyses will use the new engine.")
+            self.show_toast("Engine path updated. Future analyses will use the new engine.", "info")
         except Exception as e:
             logger.error(f"Failed to update engine: {e}")
             QMessageBox.warning(self, "Warning", f"Engine path updated, but failed to initialize: {e}")
@@ -564,16 +592,50 @@ class MainWindow(QMainWindow):
         if hasattr(self, 'history_view'):
             self.history_view.load_history()
 
+    def _apply_palette(self):
+        p = ThemeManager.palette()
+        palette = QPalette()
+        palette.setColor(QPalette.ColorRole.Window, QColor(p.background))
+        palette.setColor(QPalette.ColorRole.WindowText, QColor(p.text_primary))
+        palette.setColor(QPalette.ColorRole.Base, QColor(p.surface))
+        palette.setColor(QPalette.ColorRole.AlternateBase, QColor(p.surface_light))
+        palette.setColor(QPalette.ColorRole.ToolTipBase, QColor(p.surface_light))
+        palette.setColor(QPalette.ColorRole.ToolTipText, QColor(p.text_primary))
+        palette.setColor(QPalette.ColorRole.Text, QColor(p.text_primary))
+        palette.setColor(QPalette.ColorRole.Button, QColor(p.surface))
+        palette.setColor(QPalette.ColorRole.ButtonText, QColor(p.text_primary))
+        palette.setColor(QPalette.ColorRole.BrightText, QColor(p.accent))
+        palette.setColor(QPalette.ColorRole.Link, QColor(p.accent))
+        palette.setColor(QPalette.ColorRole.Highlight, QColor(p.accent))
+        palette.setColor(QPalette.ColorRole.HighlightedText, QColor("#FFFFFF"))
+        QApplication.setPalette(palette)
+
+    def _on_theme_changed(self, mode: str):
+        self.refresh_theme()
+
+    def _on_accent_changed(self, hex_color: str):
+        self.config_manager.set("accent_color", hex_color)
+        self.refresh_theme()
+
     def refresh_theme(self):
         """Re-applies the theme and updates widgets that need manual refresh."""
-        self.setStyleSheet(Styles.get_theme())
+        self._apply_palette()
+        theme_qss = Styles.get_theme()
+        self.setStyleSheet(theme_qss)
+        QApplication.instance().setStyleSheet(theme_qss)
         
         # Update Sidebar
-        self.sidebar.setStyleSheet(Styles.get_sidebar_style())
+        self.sidebar.apply_style()
         
         # Update Board
         if hasattr(self, 'board_widget'):
             self.board_widget.update_board()
+
+        # Update analysis page container backgrounds
+        if hasattr(self, 'left_widget') and self.left_widget:
+            self.left_widget.setStyleSheet(f"background-color: {Styles.COLOR_BACKGROUND};")
+        if hasattr(self, 'center_widget') and self.center_widget:
+            self.center_widget.setStyleSheet(f"background-color: {Styles.COLOR_BACKGROUND};")
 
         # Update Explorer Board
         if hasattr(self, 'explorer_view') and hasattr(self.explorer_view, 'board_widget'):
@@ -605,13 +667,20 @@ class MainWindow(QMainWindow):
                     background-color: {Styles.COLOR_BACKGROUND};
                     border-bottom: 1px solid {Styles.COLOR_BORDER};
                 }}
+                QFrame QLabel {{
+                    background: transparent;
+                }}
             """)
 
         # Update MainWindow Buttons
+        if hasattr(self, 'btn_explore'):
+            self.btn_explore.setStyleSheet(Styles.get_control_button_style())
         if hasattr(self, 'btn_load'):
             self.btn_load.setStyleSheet(Styles.get_control_button_style())
         if hasattr(self, 'btn_analyze'):
             self.btn_analyze.setStyleSheet(Styles.get_button_style())
+        if hasattr(self, 'game_info_label'):
+            self.game_info_label.setStyleSheet(f"font-size: 16px; font-weight: bold; color: {Styles.COLOR_TEXT_PRIMARY}; padding: 5px; background: transparent;")
         
         # Update Menu Styles
         menu_style = f"QMenu {{ background-color: {Styles.COLOR_SURFACE}; color: {Styles.COLOR_TEXT_PRIMARY}; border: 1px solid {Styles.COLOR_BORDER}; }} QMenu::item {{ padding: 5px 20px; }} QMenu::item:selected {{ background-color: {Styles.COLOR_ACCENT}; color: white; }}"
@@ -624,6 +693,25 @@ class MainWindow(QMainWindow):
         if hasattr(self, 'menu_lichess'):
             self.menu_lichess.setStyleSheet(menu_style)
         
+        # Update Captured Pieces
+        for cp in ("captured_white", "captured_black"):
+            if hasattr(self, cp):
+                w = getattr(self, cp)
+                if hasattr(w, 'refresh_styles'):
+                    w.refresh_styles()
+
+        # Update Game Controls
+        if hasattr(self, 'controls') and hasattr(self.controls, 'refresh_styles'):
+            self.controls.refresh_styles()
+
+        # Update explorer view panels
+        if hasattr(self, 'explorer_view'):
+            ev = self.explorer_view
+            if hasattr(ev, 'refresh_styles'):
+                ev.refresh_styles()
+            if hasattr(ev, 'move_list_widget') and hasattr(ev.move_list_widget, 'refresh_styles'):
+                ev.move_list_widget.refresh_styles()
+
         # Update History View
         if hasattr(self, 'history_view'):
             if hasattr(self.history_view, 'refresh_styles'):
@@ -637,7 +725,30 @@ class MainWindow(QMainWindow):
         if hasattr(self, 'tour_overlay'):
             self.tour_overlay.refresh_accent()
 
-        # Force update
+        # Update status bar
+        self.statusBar().setStyleSheet(f"""
+            QStatusBar {{
+                background-color: {Styles.COLOR_BACKGROUND};
+                border-top: 1px solid {Styles.COLOR_BORDER};
+            }}
+            QStatusBar QLabel {{
+                background: transparent;
+            }}
+        """)
+        if hasattr(self, '_status_lbl'):
+            self._status_lbl.setStyleSheet(f"font-size: 12px; color: {Styles.COLOR_TEXT_SECONDARY}; background: transparent;")
+        if hasattr(self, '_engine_pill'):
+            state = self._engine_pill.text()
+            if "Offline" in state:
+                self._engine_pill.setStyleSheet("font-size: 12px; font-weight: 600; padding: 0 6px; color: #e74c3c;")
+            elif "Calculating" in state:
+                self._engine_pill.setStyleSheet("font-size: 12px; font-weight: 600; padding: 0 6px; color: #e67e22;")
+            else:
+                self._engine_pill.setStyleSheet("font-size: 12px; font-weight: 600; padding: 0 6px; color: #27ae60;")
+
+        # Force full style re-evaluation for all children
+        self.style().unpolish(self)
+        self.style().polish(self)
         self.update()
 
     def switch_page(self, index):
@@ -929,11 +1040,20 @@ class MainWindow(QMainWindow):
         # Splitter
         splitter = QSplitter(Qt.Orientation.Horizontal)
         splitter.setHandleWidth(2)
+        splitter.setStyleSheet(f"""
+            QSplitter {{
+                background-color: {Styles.COLOR_BACKGROUND};
+            }}
+            QSplitter::handle {{
+                background-color: {Styles.COLOR_BORDER};
+            }}
+        """)
         main_layout.addWidget(splitter, 1)
         
         # Left: Move List
-        left_widget = QWidget()
-        left_layout = QVBoxLayout(left_widget)
+        self.left_widget = QWidget()
+        self.left_widget.setStyleSheet(f"background-color: {Styles.COLOR_BACKGROUND};")
+        left_layout = QVBoxLayout(self.left_widget)
         left_layout.setContentsMargins(0, 0, 0, 0)
         
         self.move_list_panel = MoveListPanel(self.engine_path, config_manager=self.config_manager)
@@ -943,11 +1063,12 @@ class MainWindow(QMainWindow):
         self.move_list_panel.live_worker.thinking_stopped.connect(self._on_live_thinking_stopped)
         left_layout.addWidget(self.move_list_panel)
         
-        splitter.addWidget(left_widget)
+        splitter.addWidget(self.left_widget)
         
         # Center: Board
-        center_widget = QWidget()
-        center_layout = QVBoxLayout(center_widget)
+        self.center_widget = QWidget()
+        self.center_widget.setStyleSheet(f"background-color: {Styles.COLOR_BACKGROUND};")
+        center_layout = QVBoxLayout(self.center_widget)
         self.center_layout = center_layout  # needed for flip_board()
         center_layout.setContentsMargins(10, 10, 10, 10)
         center_layout.setSpacing(10)
@@ -989,7 +1110,7 @@ class MainWindow(QMainWindow):
         self.controls.flip_clicked.connect(self.flip_board)
         center_layout.addWidget(self.controls)
         
-        splitter.addWidget(center_widget)
+        splitter.addWidget(self.center_widget)
         
         # Right: Analysis
         self.analysis_panel = AnalysisPanel()
@@ -1203,6 +1324,7 @@ class MainWindow(QMainWindow):
         self._full_analysis_running = False
         self._set_engine_state("ready")
         self._set_status("Analysis complete", "success")
+        self.show_toast("Analysis complete!", "success")
         logger.info("Analysis finished successfully.")
         self.current_game = game
         if hasattr(self, 'move_list_panel') and hasattr(self.move_list_panel, 'live_worker'):

--- a/src/gui/styles.py
+++ b/src/gui/styles.py
@@ -1,141 +1,140 @@
+from src.gui.theme import ThemeManager
+from src.gui.theme.palette import BOARD_THEMES
 
-class Styles:
-    # Color Palette
-    COLOR_BACKGROUND = "#1A1A1D"
-    COLOR_SURFACE = "#252529"
-    COLOR_SURFACE_LIGHT = "#2E2E33"
-    COLOR_SURFACE_CARD = "#2A2A2E"  # Slightly elevated cards
-    COLOR_TEXT_PRIMARY = "#E4E4E7"
-    COLOR_TEXT_SECONDARY = "#9CA3AF"
-    COLOR_TEXT_MUTED = "#6B7280"  # For move numbers, less important info
-    
-    # Dynamic Accent
-    COLOR_ACCENT = "#FF9500"  # Default Orange
-    COLOR_ACCENT_HOVER = "#FFB340"
-    COLOR_ACCENT_SUBTLE = "rgba(255, 149, 0, 0.15)"  # For subtle accent backgrounds
-    
-    COLOR_BORDER = "#3E3E45"
-    COLOR_BORDER_LIGHT = "#4A4A52"  # For hover states
-    COLOR_HIGHLIGHT = "#3A3A40"  # For current move row
-    
-    # Piece Colors
-    COLOR_PIECE_WHITE = "#F0F0F0"
-    COLOR_PIECE_BLACK = "#111111"
-    COLOR_BOARD_HIGHLIGHT = "#F7EC74"  # Soft yellow highlight for last move
-    
-    # Move Classification Colors (Aligned with SVG icon background fills)
-    COLOR_BRILLIANT = "#00D4AA"
-    COLOR_GREAT = "#4CACEB"
-    COLOR_BEST = "#3AAA55"
-    COLOR_EXCELLENT = "#6BBF3E"
-    COLOR_GOOD = "#4CAF76"
-    COLOR_INACCURACY = "#F1C40F"
-    COLOR_MISTAKE = "#E67E22"
-    COLOR_BLUNDER = "#D02030"
-    COLOR_MISS = "#FF5252"
-    COLOR_BOOK = "#B8956E"
 
-    # Board Themes
-    BOARD_THEMES = {
-        "Green": {"dark": "#769656", "light": "#EEEED2"},
-        "Blue": {"dark": "#4B7399", "light": "#E0E0E0"},
-        "Brown": {"dark": "#B58863", "light": "#F0D9B5"},
-        "Gray": {"dark": "#888888", "light": "#E0E0E0"},
-        "Purple": {"dark": "#9b59b6", "light": "#ecf0f1"},
-        "Teal": {"dark": "#1abc9c", "light": "#ffffff"},
-        "Cherry": {"dark": "#c0392b", "light": "#ecf0f1"},
-        "Neon": {"dark": "dynamic", "light": "#E0E0E0"} # Uses current accent
-    }
+class _StylesMeta(type):
+    @property
+    def COLOR_BACKGROUND(cls): return ThemeManager.palette().background
+    @property
+    def COLOR_SURFACE(cls): return ThemeManager.palette().surface
+    @property
+    def COLOR_SURFACE_LIGHT(cls): return ThemeManager.palette().surface_light
+    @property
+    def COLOR_SURFACE_CARD(cls): return ThemeManager.palette().surface_card
+    @property
+    def COLOR_TEXT_PRIMARY(cls): return ThemeManager.palette().text_primary
+    @property
+    def COLOR_TEXT_SECONDARY(cls): return ThemeManager.palette().text_secondary
+    @property
+    def COLOR_TEXT_MUTED(cls): return ThemeManager.palette().text_muted
+    @property
+    def COLOR_ACCENT(cls): return ThemeManager.palette().accent
+    @property
+    def COLOR_ACCENT_HOVER(cls): return ThemeManager.palette().accent_hover
+    @property
+    def COLOR_ACCENT_SUBTLE(cls): return ThemeManager.palette().accent_subtle
+    @property
+    def COLOR_BORDER(cls): return ThemeManager.palette().border
+    @property
+    def COLOR_BORDER_LIGHT(cls): return ThemeManager.palette().border_light
+    @property
+    def COLOR_HIGHLIGHT(cls): return ThemeManager.palette().highlight
+    @property
+    def COLOR_PIECE_WHITE(cls): return ThemeManager.palette().piece_white
+    @property
+    def COLOR_PIECE_BLACK(cls): return ThemeManager.palette().piece_black
+    @property
+    def COLOR_BOARD_HIGHLIGHT(cls): return ThemeManager.palette().board_highlight
+
+    @property
+    def COLOR_BRILLIANT(cls): return ThemeManager.get_class_color("Brilliant")
+    @property
+    def COLOR_GREAT(cls): return ThemeManager.get_class_color("Great")
+    @property
+    def COLOR_BEST(cls): return ThemeManager.get_class_color("Best")
+    @property
+    def COLOR_EXCELLENT(cls): return ThemeManager.get_class_color("Excellent")
+    @property
+    def COLOR_GOOD(cls): return ThemeManager.get_class_color("Good")
+    @property
+    def COLOR_INACCURACY(cls): return ThemeManager.get_class_color("Inaccuracy")
+    @property
+    def COLOR_MISTAKE(cls): return ThemeManager.get_class_color("Mistake")
+    @property
+    def COLOR_BLUNDER(cls): return ThemeManager.get_class_color("Blunder")
+    @property
+    def COLOR_MISS(cls): return ThemeManager.get_class_color("Miss")
+    @property
+    def COLOR_BOOK(cls): return ThemeManager.get_class_color("Book")
+
+    @property
+    def BOARD_THEMES(cls): return BOARD_THEMES
+
+
+class Styles(metaclass=_StylesMeta):
 
     @classmethod
     def get_board_colors(cls, theme_name="Green"):
-        theme = cls.BOARD_THEMES.get(theme_name, cls.BOARD_THEMES["Green"])
-        
-        dark = theme["dark"]
-        light = theme["light"]
-        
-        if dark == "dynamic":
-            dark = cls.COLOR_ACCENT
-            
-        return {"dark": dark, "light": light}
+        return ThemeManager.get_board_colors(theme_name)
 
     @classmethod
     def set_accent_color(cls, color_hex):
-        cls.COLOR_ACCENT = color_hex
-        cls.COLOR_ACCENT_HOVER = color_hex
-        
-        # Convert hex to rgba with 0.15 opacity for subtle backgrounds
-        hex_clean = color_hex.lstrip('#')
-        if len(hex_clean) == 6:
-            try:
-                r = int(hex_clean[0:2], 16)
-                g = int(hex_clean[2:4], 16)
-                b = int(hex_clean[4:6], 16)
-                cls.COLOR_ACCENT_SUBTLE = f"rgba({r}, {g}, {b}, 0.15)"
-            except ValueError:
-                pass
+        ThemeManager.set_accent(color_hex)
+
+    @classmethod
+    def get_class_color(cls, classification: str) -> str:
+        return ThemeManager.get_class_color(classification)
 
     @classmethod
     def get_theme(cls):
+        p = ThemeManager.palette()
         return f"""
             QMainWindow, QWidget {{
-                background-color: {cls.COLOR_BACKGROUND};
-                color: {cls.COLOR_TEXT_PRIMARY};
+                background-color: {p.background};
+                color: {p.text_primary};
                 font-family: 'SF Pro', 'Inter', 'Segoe UI', 'Roboto', sans-serif;
                 font-size: 14px;
             }}
             
             QFrame, QSplitter::handle {{
-                background-color: {cls.COLOR_SURFACE};
+                background-color: {p.surface};
             }}
             
             QSplitter::handle {{
                 width: 3px;
-                background-color: {cls.COLOR_BORDER};
+                background-color: {p.border};
             }}
             QSplitter::handle:hover {{
-                background-color: {cls.COLOR_ACCENT};
+                background-color: {p.accent};
             }}
             
-            /* Tables */
             QTableWidget {{
-                background-color: {cls.COLOR_SURFACE};
+                background-color: {p.surface};
                 gridline-color: transparent;
-                border: 1px solid {cls.COLOR_BORDER};
+                border: 1px solid {p.border};
                 border-radius: 8px;
-                selection-background-color: {cls.COLOR_HIGHLIGHT};
-                selection-color: {cls.COLOR_TEXT_PRIMARY};
+                selection-background-color: {p.highlight};
+                selection-color: {p.text_primary};
             }}
             
             QTableWidget::item {{
-                color: {cls.COLOR_TEXT_PRIMARY};
+                color: {p.text_primary};
                 padding: 10px 8px;
-                border-bottom: 1px solid {cls.COLOR_SURFACE_LIGHT};
+                border-bottom: 1px solid {p.surface_light};
             }}
             
             QTableWidget::item:hover {{
-                background-color: {cls.COLOR_SURFACE_LIGHT};
+                background-color: {p.surface_light};
             }}
             
             QTableWidget::item:selected {{
-                background-color: {cls.COLOR_HIGHLIGHT};
-                border-left: 3px solid {cls.COLOR_ACCENT};
+                background-color: {p.highlight};
+                border-left: 3px solid {p.accent};
             }}
             
             QHeaderView::section {{
-                background-color: {cls.COLOR_SURFACE_LIGHT};
-                color: {cls.COLOR_TEXT_PRIMARY};
+                background-color: {p.surface_light};
+                color: {p.text_primary};
                 padding: 8px;
                 border: none;
-                border-bottom: 2px solid {cls.COLOR_ACCENT};
+                border-bottom: 2px solid {p.accent};
                 font-weight: 600;
                 font-size: 13px;
             }}
             
-            /* Lists */
             QListWidget {{
-                background-color: {cls.COLOR_SURFACE};
-                border: 1px solid {cls.COLOR_BORDER};
+                background-color: {p.surface};
+                border: 1px solid {p.border};
                 border-radius: 8px;
                 padding: 6px;
             }}
@@ -147,111 +146,109 @@ class Styles:
             }}
             
             QListWidget::item:hover {{
-                background-color: {cls.COLOR_SURFACE_LIGHT};
+                background-color: {p.surface_light};
             }}
 
             QListWidget::item:selected {{
-                background-color: {cls.COLOR_ACCENT};
+                background-color: {p.accent};
                 color: white;
             }}
             
-            /* Labels */
             QLabel {{
-                color: {cls.COLOR_TEXT_PRIMARY};
+                color: {p.text_primary};
                 background: transparent;
             }}
             
-            /* Scrollbars */
             QScrollBar:vertical {{
                 border: none;
-                background: {cls.COLOR_BACKGROUND};
+                background: {p.background};
                 width: 8px;
                 margin: 4px 2px;
             }}
             QScrollBar::handle:vertical {{
-                background: {cls.COLOR_BORDER};
+                background: {p.border};
                 min-height: 30px;
                 border-radius: 4px;
             }}
             QScrollBar::handle:vertical:hover {{
-                background: {cls.COLOR_BORDER_LIGHT};
+                background: {p.border_light};
             }}
             QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {{
                 height: 0px;
             }}
             
-            /* Horizontal Scrollbar */
             QScrollBar:horizontal {{
                 border: none;
-                background: {cls.COLOR_BACKGROUND};
+                background: {p.background};
                 height: 8px;
                 margin: 2px 4px;
             }}
             QScrollBar::handle:horizontal {{
-                background: {cls.COLOR_BORDER};
+                background: {p.border};
                 min-width: 30px;
                 border-radius: 4px;
             }}
             QScrollBar::handle:horizontal:hover {{
-                background: {cls.COLOR_BORDER_LIGHT};
+                background: {p.border_light};
             }}
             QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {{
                 width: 0px;
             }}
             
-            /* Tooltips */
             QToolTip {{
-                background-color: {cls.COLOR_SURFACE_LIGHT};
-                color: {cls.COLOR_TEXT_PRIMARY};
-                border: 1px solid {cls.COLOR_BORDER};
+                background-color: {p.surface_light};
+                color: {p.text_primary};
+                border: 1px solid {p.border};
                 border-radius: 4px;
                 padding: 6px 10px;
                 font-size: 13px;
             }}
         """
     
-    CAPTURED_PIECES_STYLE = f"""
-        QLabel {{
+    CAPTURED_PIECES_STYLE = """
+        QLabel {
             font-size: 16px;
             font-weight: bold;
             padding: 2px;
-        }}
+        }
     """
     
     @classmethod
     def get_control_button_style(cls):
+        p = ThemeManager.palette()
         return f"""
             QPushButton {{
-                background-color: {cls.COLOR_SURFACE_LIGHT};
-                color: {cls.COLOR_TEXT_PRIMARY};
-                border: 1px solid {cls.COLOR_BORDER};
+                background-color: {p.surface_light};
+                color: {p.text_primary};
+                border: 1px solid {p.border};
                 border-radius: 6px;
                 padding: 8px 16px;
                 font-size: 13px;
                 font-weight: 500;
             }}
             QPushButton:hover {{
-                background-color: {cls.COLOR_SURFACE};
-                border: 1px solid {cls.COLOR_ACCENT};
+                background-color: {p.surface};
+                border: 1px solid {p.accent};
             }}
             QPushButton:pressed {{
-                background-color: {cls.COLOR_ACCENT_SUBTLE};
-                border: 1px solid {cls.COLOR_ACCENT};
+                background-color: {p.accent_subtle};
+                border: 1px solid {p.accent};
             }}
             QPushButton:disabled {{
-                background-color: {cls.COLOR_SURFACE_LIGHT};
-                color: {cls.COLOR_TEXT_MUTED};
-                border-color: {cls.COLOR_BORDER};
+                background-color: {p.surface_light};
+                color: {p.text_muted};
+                border-color: {p.border};
             }}
         """
 
     @classmethod
     def get_export_button_style(cls):
+        p = ThemeManager.palette()
         return f"""
             QPushButton {{
-                background-color: #2D5A27; /* Dark Green */
+                background-color: #2D5A27;
                 color: white;
-                border: 1px solid {cls.COLOR_BORDER};
+                border: 1px solid {p.border};
                 border-radius: 4px;
                 padding: 6px 12px;
                 font-size: 14px;
@@ -267,6 +264,7 @@ class Styles:
 
     @classmethod
     def get_import_button_style(cls):
+        p = ThemeManager.palette()
         return f"""
             QPushButton {{
                 background-color: #2D4A6B;
@@ -288,9 +286,10 @@ class Styles:
     
     @classmethod
     def get_button_style(cls):
+        p = ThemeManager.palette()
         return f"""
             QPushButton {{
-                background-color: {cls.COLOR_ACCENT};
+                background-color: {p.accent};
                 color: white;
                 border: none;
                 padding: 8px 16px;
@@ -299,23 +298,24 @@ class Styles:
                 font-size: 13px;
             }}
             QPushButton:hover {{
-                background-color: {cls.COLOR_ACCENT_HOVER};
+                background-color: {p.accent_hover};
             }}
             QPushButton:pressed {{
-                background-color: {cls.COLOR_ACCENT};
+                background-color: {p.accent};
             }}
             QPushButton:disabled {{
-                background-color: {cls.COLOR_BORDER};
-                color: {cls.COLOR_TEXT_MUTED};
+                background-color: {p.border};
+                color: {p.text_muted};
             }}
         """
     
     @classmethod
     def get_sidebar_style(cls):
+        p = ThemeManager.palette()
         return f"""
             #Sidebar {{
-                background-color: {cls.COLOR_SURFACE};
-                border-right: 1px solid {cls.COLOR_BORDER};
+                background-color: {p.surface};
+                border-right: 1px solid {p.border};
             }}
             QPushButton {{
                 background-color: transparent;
@@ -325,62 +325,80 @@ class Styles:
                 text-align: left;
                 font-size: 14px;
                 font-weight: 500;
-                color: {cls.COLOR_TEXT_SECONDARY};
+                color: {p.text_secondary};
             }}
             QPushButton:hover {{
-                background-color: {cls.COLOR_SURFACE_LIGHT};
-                color: {cls.COLOR_TEXT_PRIMARY};
+                background-color: {p.surface_light};
+                color: {p.text_primary};
             }}
             QPushButton:checked {{
-                background-color: {cls.COLOR_ACCENT};
+                background-color: {p.accent};
                 color: white;
                 font-weight: 600;
             }}
         """
 
-    @staticmethod
-    def get_class_color(classification: str) -> str:
-        mapping = {
-            "Brilliant": Styles.COLOR_BRILLIANT,
-            "Great": Styles.COLOR_GREAT,
-            "Best": Styles.COLOR_BEST,
-            "Excellent": Styles.COLOR_EXCELLENT,
-            "Good": Styles.COLOR_GOOD,
-            "Book": Styles.COLOR_BOOK,
-            "Inaccuracy": Styles.COLOR_INACCURACY,
-            "Mistake": Styles.COLOR_MISTAKE,
-            "Blunder": Styles.COLOR_BLUNDER,
-            "Miss": Styles.COLOR_MISS,
-        }
-        return mapping.get(classification, Styles.COLOR_TEXT_PRIMARY)
+    @classmethod
+    def get_focus_ring_style(cls):
+        p = ThemeManager.palette()
+        return f"""
+            QLineEdit {{
+                padding: 10px;
+                border: 1px solid {p.border};
+                border-radius: 4px;
+                background-color: {p.surface_light};
+                color: {p.text_primary};
+            }}
+            QLineEdit:focus {{
+                border: 2px solid {p.accent};
+                padding: 9px;
+            }}
+            QComboBox {{
+                padding: 8px 12px;
+                border: 1px solid {p.border};
+                border-radius: 6px;
+                background-color: {p.surface_light};
+                color: {p.text_primary};
+            }}
+            QComboBox:focus {{
+                border: 2px solid {p.accent};
+            }}
+            QPushButton:focus {{
+                outline: 2px solid {p.accent};
+            }}
+            QTextEdit:focus {{
+                border: 2px solid {p.accent};
+            }}
+            QListWidget:focus {{
+                border: 2px solid {p.accent};
+            }}
+        """
 
-    # ============== Consolidated Style Helpers ==============
-    
     @classmethod
     def get_input_style(cls):
-        """Standard input field style for QLineEdit."""
+        p = ThemeManager.palette()
         return f"""
             padding: 10px;
-            border: 1px solid {cls.COLOR_BORDER};
+            border: 1px solid {p.border};
             border-radius: 4px;
-            background-color: {cls.COLOR_SURFACE_LIGHT};
-            color: {cls.COLOR_TEXT_PRIMARY};
+            background-color: {p.surface_light};
+            color: {p.text_primary};
         """
     
     @classmethod
     def get_label_style(cls, size=14, color=None, bold=False):
-        """Standard label style with configurable size and color."""
+        p = ThemeManager.palette()
         if color is None:
-            color = cls.COLOR_TEXT_PRIMARY
+            color = p.text_primary
         weight = "bold" if bold else "normal"
         return f"font-size: {size}px; color: {color}; font-weight: {weight};"
     
     @classmethod
     def get_secondary_label_style(cls, size=13):
-        """Secondary/muted label style with transparent background."""
+        p = ThemeManager.palette()
         return f"""
             font-size: {size}px; 
-            color: {cls.COLOR_TEXT_SECONDARY}; 
+            color: {p.text_secondary}; 
             background-color: transparent;
             border: none;
             padding: 4px 0px;
@@ -388,17 +406,17 @@ class Styles:
     
     @classmethod
     def get_frame_style(cls, border_radius=12, hover_accent=True):
-        """Card/frame style with optional hover effect."""
+        p = ThemeManager.palette()
         hover_style = f"""
             QFrame:hover {{
-                border: 1px solid {cls.COLOR_ACCENT};
+                border: 1px solid {p.accent};
             }}
         """ if hover_accent else ""
         
         return f"""
             QFrame {{
-                background-color: {cls.COLOR_SURFACE};
-                border: 1px solid {cls.COLOR_BORDER};
+                background-color: {p.surface};
+                border: 1px solid {p.border};
                 border-radius: {border_radius}px;
             }}
             {hover_style}
@@ -406,104 +424,103 @@ class Styles:
     
     @classmethod
     def get_card_style(cls, border_radius=12):
-        """Dashboard card style with hover effect."""
+        p = ThemeManager.palette()
         return f"""
             QFrame {{
-                background-color: {cls.COLOR_SURFACE};
-                border: 1px solid {cls.COLOR_BORDER};
+                background-color: {p.surface};
+                border: 1px solid {p.border};
                 border-radius: {border_radius}px;
             }}
             QFrame:hover {{
-                border: 1px solid {cls.COLOR_ACCENT};
-                background-color: {cls.COLOR_SURFACE_LIGHT};
+                border: 1px solid {p.accent};
+                background-color: {p.surface_light};
             }}
         """
     
     @classmethod
     def get_combobox_style(cls):
-        """Standard combobox/dropdown style."""
+        p = ThemeManager.palette()
         return f"""
             QComboBox {{
                 padding: 8px 12px;
-                border: 1px solid {cls.COLOR_BORDER};
+                border: 1px solid {p.border};
                 border-radius: 6px;
-                background-color: {cls.COLOR_SURFACE_LIGHT};
-                color: {cls.COLOR_TEXT_PRIMARY};
+                background-color: {p.surface_light};
+                color: {p.text_primary};
                 min-width: 150px;
             }}
             QComboBox:hover {{
-                border: 1px solid {cls.COLOR_ACCENT};
+                border: 1px solid {p.accent};
             }}
             QComboBox::drop-down {{
                 border: none;
                 padding-right: 10px;
             }}
             QComboBox QAbstractItemView {{
-                background-color: {cls.COLOR_SURFACE};
-                color: {cls.COLOR_TEXT_PRIMARY};
-                selection-background-color: {cls.COLOR_ACCENT};
+                background-color: {p.surface};
+                color: {p.text_primary};
+                selection-background-color: {p.accent};
                 selection-color: white;
-                border: 1px solid {cls.COLOR_BORDER};
+                border: 1px solid {p.border};
             }}
         """
     
     @classmethod
     def get_group_box_style(cls):
-        """Standard QGroupBox style for settings sections."""
+        p = ThemeManager.palette()
         return f"""
             QGroupBox {{
                 font-size: 16px;
                 font-weight: bold;
-                color: {cls.COLOR_TEXT_PRIMARY};
-                border: 1px solid {cls.COLOR_BORDER};
+                color: {p.text_primary};
+                border: 1px solid {p.border};
                 border-radius: 8px;
                 margin-top: 20px;
                 padding: 20px 15px 15px 15px;
-                background-color: {cls.COLOR_SURFACE};
+                background-color: {p.surface};
             }}
             QGroupBox::title {{
                 subcontrol-origin: margin;
                 subcontrol-position: top left;
                 left: 15px;
                 padding: 0 5px;
-                background-color: {cls.COLOR_BACKGROUND};
+                background-color: {p.background};
             }}
         """
     
     @classmethod
     def get_text_edit_style(cls):
-        """Standard QTextEdit style."""
+        p = ThemeManager.palette()
         return f"""
             QTextEdit {{
-                background-color: {cls.COLOR_SURFACE_LIGHT};
-                border: 1px solid {cls.COLOR_BORDER};
+                background-color: {p.surface_light};
+                border: 1px solid {p.border};
                 border-radius: 8px;
                 padding: 10px;
-                color: {cls.COLOR_TEXT_PRIMARY};
+                color: {p.text_primary};
             }}
         """
     
     @classmethod
     def get_progress_bar_style(cls):
-        """Standard progress bar style."""
+        p = ThemeManager.palette()
         return f"""
             QProgressBar {{
-                border: 2px solid {cls.COLOR_BORDER};
+                border: 2px solid {p.border};
                 border-radius: 5px;
-                background-color: {cls.COLOR_SURFACE};
+                background-color: {p.surface};
                 text-align: center;
-                color: {cls.COLOR_TEXT_PRIMARY};
+                color: {p.text_primary};
                 font-size: 12px;
                 font-weight: bold;
                 min-height: 22px;
             }}
             QProgressBar::chunk {{
-                background-color: {cls.COLOR_ACCENT};
+                background-color: {p.accent};
                 border-radius: 3px;
             }}
         """
     
     @classmethod
     def get_transparent_label_style(cls):
-        """Label with transparent background (for use in styled frames)."""
         return "border: none; background: transparent;"

--- a/src/gui/theme/__init__.py
+++ b/src/gui/theme/__init__.py
@@ -1,0 +1,4 @@
+from .palette import ThemePalette, DARK, LIGHT, CLASSIFICATION_COLORS, BOARD_THEMES
+from .manager import ThemeManager, ELEVATIONS, Elevation
+from .system import get_system_accent, OSThemeWatcher
+from .tokens import Spacing, Radius, TypeScale

--- a/src/gui/theme/manager.py
+++ b/src/gui/theme/manager.py
@@ -1,0 +1,149 @@
+from dataclasses import dataclass
+
+from PyQt6.QtCore import QObject, pyqtSignal
+from PyQt6.QtGui import QColor
+from PyQt6.QtWidgets import QGraphicsDropShadowEffect
+
+from .palette import ThemePalette, DARK, LIGHT, CLASSIFICATION_COLORS, BOARD_THEMES
+from .system import OSThemeWatcher, get_system_accent
+
+
+@dataclass
+class Elevation:
+    blur_radius: int
+    x_offset: int
+    y_offset: int
+    opacity: int
+
+
+ELEVATIONS = {
+    0: Elevation(0, 0, 0, 0),
+    1: Elevation(10, 0, 2, 40),
+    2: Elevation(16, 0, 4, 60),
+    3: Elevation(24, 0, 8, 80),
+}
+
+
+class ThemeManager(QObject):
+    theme_changed = pyqtSignal(str)
+    accent_changed = pyqtSignal(str)
+
+    _instance: "ThemeManager | None" = None
+
+    _current_mode: str = "dark"
+    _theme_mode: str = "system"  # "system" | "dark" | "light"
+    _palette: ThemePalette = DARK
+    _accent: str = "#FF9500"
+    _accent_mode: str = "system"  # "system" | "manual"
+    _os_watcher: OSThemeWatcher | None = None
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        ThemeManager._instance = self
+        self._os_watcher = OSThemeWatcher(self)
+        self._os_watcher.color_scheme_changed.connect(self._on_os_scheme_changed)
+
+    def _on_os_scheme_changed(self, mode: str):
+        if self._theme_mode == "system":
+            self.set_mode(mode)
+
+    @classmethod
+    def instance(cls) -> "ThemeManager":
+        if cls._instance is None:
+            cls._instance = ThemeManager()
+        return cls._instance
+
+    @classmethod
+    def palette(cls) -> ThemePalette:
+        return cls._palette
+
+    @classmethod
+    def mode(cls) -> str:
+        return cls._current_mode
+
+    @classmethod
+    def theme_mode(cls) -> str:
+        return cls._theme_mode
+
+    @classmethod
+    def accent(cls) -> str:
+        return cls._accent
+
+    @classmethod
+    def accent_mode(cls) -> str:
+        return cls._accent_mode
+
+    @classmethod
+    def get_class_color(cls, classification: str) -> str:
+        return CLASSIFICATION_COLORS.get(classification, cls._palette.text_primary)
+
+    @classmethod
+    def get_board_colors(cls, theme_name: str = "Green") -> dict:
+        theme = BOARD_THEMES.get(theme_name, BOARD_THEMES["Green"])
+        dark = theme["dark"]
+        light = theme["light"]
+        if dark == "dynamic":
+            dark = cls._accent
+        return {"dark": dark, "light": light}
+
+    @classmethod
+    def set_theme_mode(cls, mode: str):
+        """Set theme mode: 'system', 'dark', or 'light'."""
+        cls._theme_mode = mode
+        if mode == "system":
+            detected = OSThemeWatcher.current_scheme()
+            cls.set_mode(detected)
+        else:
+            cls.set_mode(mode)
+
+    @classmethod
+    def set_mode(cls, mode: str):
+        if mode == cls._current_mode:
+            return
+        cls._current_mode = mode
+        cls._palette = DARK if mode == "dark" else LIGHT
+        cls._palette = cls._palette.with_accent(cls._accent)
+        instance = cls.instance()
+        instance.theme_changed.emit(mode)
+
+    @classmethod
+    def toggle_mode(cls):
+        cls.set_mode("light" if cls._current_mode == "dark" else "dark")
+
+    @classmethod
+    def set_accent_mode(cls, mode: str):
+        """Set accent mode: 'system' or 'manual'."""
+        cls._accent_mode = mode
+        if mode == "system":
+            detected = get_system_accent()
+            if detected:
+                cls.set_accent(detected)
+
+    @classmethod
+    def set_accent(cls, hex_color: str):
+        cls._accent = hex_color
+        cls._palette = cls._palette.with_accent(hex_color)
+        instance = cls.instance()
+        instance.accent_changed.emit(hex_color)
+
+    @classmethod
+    def refresh_system_accent(cls):
+        """Re-read system accent and apply if in system mode."""
+        if cls._accent_mode == "system":
+            detected = get_system_accent(force=True)
+            if detected:
+                cls.set_accent(detected)
+
+    @classmethod
+    def drop_shadow(cls, elevation: int = 1) -> QGraphicsDropShadowEffect:
+        elev = ELEVATIONS.get(elevation, ELEVATIONS[1])
+        shadow = QGraphicsDropShadowEffect()
+        shadow.setBlurRadius(elev.blur_radius)
+        shadow.setOffset(elev.x_offset, elev.y_offset)
+        shadow.setColor(QColor(0, 0, 0, elev.opacity))
+        return shadow
+
+    @classmethod
+    def apply_elevation(cls, widget, elevation: int = 1):
+        shadow = cls.drop_shadow(elevation)
+        widget.setGraphicsEffect(shadow)

--- a/src/gui/theme/palette.py
+++ b/src/gui/theme/palette.py
@@ -1,0 +1,110 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class ThemePalette:
+    background: str
+    surface: str
+    surface_light: str
+    surface_card: str
+    border: str
+    border_light: str
+    highlight: str
+    text_primary: str
+    text_secondary: str
+    text_muted: str
+    accent: str = "#FF9500"
+    accent_hover: str = "#FFB340"
+    accent_subtle: str = "rgba(255, 149, 0, 0.15)"
+
+    piece_white: str = "#F0F0F0"
+    piece_black: str = "#111111"
+    board_highlight: str = "#F7EC74"
+
+    def with_accent(self, hex_color: str) -> "ThemePalette":
+        r = int(hex_color[1:3], 16)
+        g = int(hex_color[3:5], 16)
+        b = int(hex_color[5:7], 16)
+        subtle = f"rgba({r}, {g}, {b}, 0.15)"
+        return ThemePalette(
+            background=self.background,
+            surface=self.surface,
+            surface_light=self.surface_light,
+            surface_card=self.surface_card,
+            border=self.border,
+            border_light=self.border_light,
+            highlight=self.highlight,
+            text_primary=self.text_primary,
+            text_secondary=self.text_secondary,
+            text_muted=self.text_muted,
+            accent=hex_color,
+            accent_hover=hex_color,
+            accent_subtle=subtle,
+            piece_white=self.piece_white,
+            piece_black=self.piece_black,
+            board_highlight=self.board_highlight,
+        )
+
+
+DARK = ThemePalette(
+    background="#1A1A1D",
+    surface="#252529",
+    surface_light="#2E2E33",
+    surface_card="#2A2A2E",
+    border="#3E3E45",
+    border_light="#4A4A52",
+    highlight="#3A3A40",
+    text_primary="#E4E4E7",
+    text_secondary="#9CA3AF",
+    text_muted="#6B7280",
+    accent="#FF9500",
+    accent_hover="#FFB340",
+    accent_subtle="rgba(255, 149, 0, 0.15)",
+    piece_white="#F0F0F0",
+    piece_black="#111111",
+    board_highlight="#F7EC74",
+)
+
+LIGHT = ThemePalette(
+    background="#F5F5F7",
+    surface="#FFFFFF",
+    surface_light="#EBEBED",
+    surface_card="#F0F0F2",
+    border="#C7C7CC",
+    border_light="#B0B0B5",
+    highlight="#DCDCE0",
+    text_primary="#1D1D1F",
+    text_secondary="#6E6E73",
+    text_muted="#8E8E93",
+    accent="#FF9500",
+    accent_hover="#E08600",
+    accent_subtle="rgba(255, 149, 0, 0.15)",
+    piece_white="#F0F0F0",
+    piece_black="#111111",
+    board_highlight="#F7EC74",
+)
+
+CLASSIFICATION_COLORS = {
+    "Brilliant": "#00D4AA",
+    "Great": "#4CACEB",
+    "Best": "#3AAA55",
+    "Excellent": "#6BBF3E",
+    "Good": "#4CAF76",
+    "Inaccuracy": "#F1C40F",
+    "Mistake": "#E67E22",
+    "Blunder": "#D02030",
+    "Miss": "#FF5252",
+    "Book": "#B8956E",
+}
+
+BOARD_THEMES = {
+    "Green": {"dark": "#769656", "light": "#EEEED2"},
+    "Blue": {"dark": "#4B7399", "light": "#E0E0E0"},
+    "Brown": {"dark": "#B58863", "light": "#F0D9B5"},
+    "Gray": {"dark": "#888888", "light": "#E0E0E0"},
+    "Purple": {"dark": "#9b59b6", "light": "#ecf0f1"},
+    "Teal": {"dark": "#1abc9c", "light": "#ffffff"},
+    "Cherry": {"dark": "#c0392b", "light": "#ecf0f1"},
+    "Neon": {"dark": "dynamic", "light": "#E0E0E0"},
+}

--- a/src/gui/theme/system.py
+++ b/src/gui/theme/system.py
@@ -1,0 +1,74 @@
+import subprocess
+import sys
+
+from PyQt6.QtCore import QObject, Qt, pyqtSignal
+from PyQt6.QtGui import QGuiApplication, QPalette
+from PyQt6.QtWidgets import QApplication
+
+MACOS_ACCENT_MAP = {
+    -1: "#8E8E93",  # Graphite
+    0: "#FF3B30",   # Red
+    1: "#FF9500",   # Orange
+    2: "#FFCC00",   # Yellow
+    3: "#34C759",   # Green
+    4: "#007AFF",   # Blue
+    5: "#AF52DE",   # Purple
+    6: "#FF2D55",   # Pink
+}
+
+_ACCENT_CACHE: str | None = None
+
+
+def get_system_accent(force: bool = False) -> str | None:
+    global _ACCENT_CACHE
+    if _ACCENT_CACHE and not force:
+        return _ACCENT_CACHE
+
+    if sys.platform == "darwin":
+        try:
+            result = subprocess.run(
+                ["defaults", "read", "-g", "AppleAccentColor"],
+                capture_output=True, text=True, timeout=2,
+            )
+            if result.returncode == 0:
+                value = int(result.stdout.strip())
+                color = MACOS_ACCENT_MAP.get(value)
+                if color:
+                    _ACCENT_CACHE = color
+                    return color
+        except (ValueError, subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+
+    try:
+        palette = QApplication.style().standardPalette()
+        accent = palette.color(QPalette.ColorRole.Accent)
+        color = accent.name()
+        _ACCENT_CACHE = color
+        return color
+    except Exception:
+        return None
+
+
+class OSThemeWatcher(QObject):
+    color_scheme_changed = pyqtSignal(str)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        hints = QGuiApplication.styleHints()
+        hints.colorSchemeChanged.connect(self._on_scheme_changed)
+
+    def _on_scheme_changed(self, scheme):
+        mode = "dark" if scheme == Qt.ColorScheme.Dark else "light"
+        self.color_scheme_changed.emit(mode)
+
+    @staticmethod
+    def current_scheme() -> str:
+        scheme = QGuiApplication.styleHints().colorScheme()
+        return "dark" if scheme == Qt.ColorScheme.Dark else "light"
+
+    def cleanup(self):
+        try:
+            hints = QGuiApplication.styleHints()
+            hints.colorSchemeChanged.disconnect(self._on_scheme_changed)
+        except (TypeError, RuntimeError):
+            pass

--- a/src/gui/theme/tokens.py
+++ b/src/gui/theme/tokens.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+
+
+class Spacing:
+    XS = 4
+    SM = 8
+    MD = 12
+    LG = 16
+    XL = 24
+    XXL = 32
+    XXXL = 48
+
+
+class Radius:
+    SM = 4
+    MD = 6
+    LG = 8
+    XL = 12
+    XXL = 16
+
+
+@dataclass
+class TypeScale:
+    display: int = 28
+    heading: int = 18
+    body: int = 14
+    small: int = 12
+    tiny: int = 11
+    stat_value: int = 42

--- a/src/gui/views/explorer_view.py
+++ b/src/gui/views/explorer_view.py
@@ -135,9 +135,9 @@ class ExplorerView(QWidget):
         header_layout.setContentsMargins(20, 6, 20, 6)
 
         # Title
-        title_lbl = QLabel("Opening Explorer")
-        title_lbl.setStyleSheet(f"font-size: 16px; font-weight: bold; color: {Styles.COLOR_TEXT_PRIMARY}; background: transparent; border: none;")
-        header_layout.addWidget(title_lbl)
+        self.title_lbl = QLabel("Opening Explorer")
+        self.title_lbl.setStyleSheet(f"font-size: 16px; font-weight: bold; color: {Styles.COLOR_TEXT_PRIMARY}; background: transparent; border: none;")
+        header_layout.addWidget(self.title_lbl)
 
         # Opening badge (inline after title)
         self.opening_badge = QLabel("Opening: -")
@@ -185,15 +185,19 @@ class ExplorerView(QWidget):
         main_layout.addWidget(self.header_bar)
         
         # Content Area - Splitter
-        splitter = QSplitter(Qt.Orientation.Horizontal)
-        splitter.setHandleWidth(2)
-        splitter.setStyleSheet(f"QSplitter::handle {{ background-color: {Styles.COLOR_BORDER}; }}")
+        self.splitter = QSplitter(Qt.Orientation.Horizontal)
+        self.splitter.setHandleWidth(2)
+        self.splitter.setStyleSheet(f"""
+            QSplitter {{ background-color: {Styles.COLOR_BACKGROUND}; }}
+            QSplitter::handle {{ background-color: {Styles.COLOR_BORDER}; }}
+        """)
         
         # ==========================================
         # LEFT PANEL (Board & Eval)
         # ==========================================
-        left_panel = QWidget()
-        self.left_layout = QVBoxLayout(left_panel)
+        self.left_panel = QWidget()
+        self.left_panel.setStyleSheet(f"background-color: {Styles.COLOR_BACKGROUND};")
+        self.left_layout = QVBoxLayout(self.left_panel)
         self.left_layout.setContentsMargins(8, 8, 8, 8)
         self.left_layout.setSpacing(6)
         
@@ -201,10 +205,10 @@ class ExplorerView(QWidget):
         self.black_header_widget = QWidget()
         black_header = QHBoxLayout(self.black_header_widget)
         black_header.setContentsMargins(0, 0, 0, 0)
-        lbl_black = QLabel("Black")
-        lbl_black.setStyleSheet(Styles.get_label_style(size=16, bold=True))
+        self.lbl_black = QLabel("Black")
+        self.lbl_black.setStyleSheet(Styles.get_label_style(size=16, bold=True))
         self.captured_black = CapturedPiecesWidget(side="black")
-        black_header.addWidget(lbl_black)
+        black_header.addWidget(self.lbl_black)
         black_header.addWidget(self.captured_black)
         black_header.addStretch()
         self.left_layout.addWidget(self.black_header_widget)
@@ -218,21 +222,22 @@ class ExplorerView(QWidget):
         self.white_header_widget = QWidget()
         white_header = QHBoxLayout(self.white_header_widget)
         white_header.setContentsMargins(0, 0, 0, 0)
-        lbl_white = QLabel("White")
-        lbl_white.setStyleSheet(Styles.get_label_style(size=16, bold=True))
+        self.lbl_white = QLabel("White")
+        self.lbl_white.setStyleSheet(Styles.get_label_style(size=16, bold=True))
         self.captured_white = CapturedPiecesWidget(side="white")
-        white_header.addWidget(lbl_white)
+        white_header.addWidget(self.lbl_white)
         white_header.addWidget(self.captured_white)
         white_header.addStretch()
         self.left_layout.addWidget(self.white_header_widget)
         
-        splitter.addWidget(left_panel)
+        self.splitter.addWidget(self.left_panel)
         
         # ==========================================
         # RIGHT PANEL (Controls & Analysis)
         # ==========================================
-        right_panel = QWidget()
-        right_layout = QVBoxLayout(right_panel)
+        self.right_panel = QWidget()
+        self.right_panel.setStyleSheet(f"background-color: {Styles.COLOR_BACKGROUND};")
+        right_layout = QVBoxLayout(self.right_panel)
         right_layout.setContentsMargins(8, 8, 12, 8)
         right_layout.setSpacing(6)
         
@@ -337,9 +342,9 @@ class ExplorerView(QWidget):
         moves_header = QHBoxLayout()
         moves_header.setContentsMargins(0, 0, 0, 0)
         moves_header.setSpacing(8)
-        move_list_label = QLabel("Moves")
-        move_list_label.setStyleSheet(Styles.get_label_style(size=14, bold=True))
-        moves_header.addWidget(move_list_label)
+        self.move_list_label = QLabel("Moves")
+        self.move_list_label.setStyleSheet(Styles.get_label_style(size=14, bold=True))
+        moves_header.addWidget(self.move_list_label)
         self.move_input = QLineEdit()
         self.move_input.setPlaceholderText("type SAN move...")
         self.move_input.setToolTip("Enter a move in standard algebraic notation (e.g. e4, Nf3, O-O)")
@@ -376,9 +381,9 @@ class ExplorerView(QWidget):
         self.engine_status_label.setStyleSheet(f"font-size: 11px; color: {Styles.COLOR_TEXT_MUTED}; padding: 2px 0px;")
         right_layout.addWidget(self.engine_status_label)
         
-        splitter.addWidget(right_panel)
-        splitter.setSizes([700, 450])
-        main_layout.addWidget(splitter, 1)
+        self.splitter.addWidget(self.right_panel)
+        self.splitter.setSizes([700, 450])
+        main_layout.addWidget(self.splitter, 1)
 
     def load_fen(self, fen):
         """Loads a starting position into the explorer."""
@@ -1144,5 +1149,113 @@ class ExplorerView(QWidget):
                 background-color: {Styles.COLOR_BACKGROUND};
                 border-bottom: 1px solid {Styles.COLOR_BORDER};
             }}
+            QFrame QLabel {{
+                background: transparent;
+            }}
         """)
-        self.setStyleSheet(Styles.get_theme())
+        # Update title and player labels
+        if hasattr(self, 'title_lbl'):
+            self.title_lbl.setStyleSheet(f"font-size: 16px; font-weight: bold; color: {Styles.COLOR_TEXT_PRIMARY}; background: transparent; border: none;")
+        if hasattr(self, 'lbl_black'):
+            self.lbl_black.setStyleSheet(Styles.get_label_style(size=16, bold=True))
+        if hasattr(self, 'lbl_white'):
+            self.lbl_white.setStyleSheet(Styles.get_label_style(size=16, bold=True))
+        if hasattr(self, 'move_list_label'):
+            self.move_list_label.setStyleSheet(Styles.get_label_style(size=14, bold=True))
+        # Update panel backgrounds
+        if hasattr(self, 'left_panel'):
+            self.left_panel.setStyleSheet(f"background-color: {Styles.COLOR_BACKGROUND};")
+        if hasattr(self, 'right_panel'):
+            self.right_panel.setStyleSheet(f"background-color: {Styles.COLOR_BACKGROUND};")
+        if hasattr(self, 'splitter'):
+            self.splitter.setStyleSheet(f"""
+                QSplitter {{ background-color: {Styles.COLOR_BACKGROUND}; }}
+                QSplitter::handle {{ background-color: {Styles.COLOR_BORDER}; }}
+            """)
+        self.opening_badge.setStyleSheet(f"font-size: 13px; color: {Styles.COLOR_TEXT_SECONDARY}; padding: 0px 0px 0px 12px; background: transparent; border: none;")
+        btn_style = f"""
+            QPushButton {{
+                background-color: {Styles.COLOR_SURFACE};
+                color: {Styles.COLOR_TEXT_SECONDARY};
+                border: 1px solid {Styles.COLOR_BORDER};
+                border-radius: 6px;
+                padding: 4px 10px;
+                font-size: 11px;
+                font-weight: 600;
+            }}
+            QPushButton:hover {{
+                background-color: {Styles.COLOR_SURFACE_LIGHT};
+                border-color: {Styles.COLOR_ACCENT};
+                color: {Styles.COLOR_TEXT_PRIMARY};
+            }}
+        """
+        self.btn_flip.setStyleSheet(btn_style)
+        self.btn_copy_fen.setStyleSheet(btn_style)
+        self.btn_copy_pgn.setStyleSheet(btn_style)
+        chk_style = f"""
+            QCheckBox {{
+                color: {Styles.COLOR_TEXT_SECONDARY};
+                font-size: 12px;
+                font-weight: 500;
+            }}
+        """
+        self.chk_classify.setStyleSheet(chk_style)
+        self.chk_legal.setStyleSheet(chk_style)
+        self.chk_engine.setStyleSheet(chk_style)
+        self.chk_cache.setStyleSheet(chk_style)
+        self.lines_widget.refresh_styles()
+        self.book_toggle.setStyleSheet(f"""
+            QPushButton {{
+                background: transparent;
+                border: none;
+                text-align: left;
+                font-size: 14px;
+                font-weight: bold;
+                color: {Styles.COLOR_TEXT_PRIMARY};
+                padding: 2px 0px;
+            }}
+            QPushButton:hover {{
+                color: {Styles.COLOR_ACCENT};
+            }}
+        """)
+        self.book_scroll.setStyleSheet(f"""
+            QScrollArea {{
+                background-color: {Styles.COLOR_SURFACE};
+                border: 1px solid {Styles.COLOR_BORDER};
+                border-radius: 8px;
+            }}
+            QScrollBar:vertical {{
+                background-color: {Styles.COLOR_BACKGROUND};
+                width: 10px;
+                margin: 0px 0px 0px 0px;
+                border-radius: 5px;
+            }}
+            QScrollBar::handle:vertical {{
+                background-color: {Styles.COLOR_BORDER_LIGHT};
+                min-height: 20px;
+                border-radius: 5px;
+            }}
+            QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {{
+                height: 0px;
+            }}
+        """)
+        self.book_container.setStyleSheet(f"background-color: {Styles.COLOR_SURFACE};")
+        self.move_input.setStyleSheet(f"""
+            QLineEdit {{
+                background-color: {Styles.COLOR_SURFACE};
+                color: {Styles.COLOR_TEXT_PRIMARY};
+                border: 1px solid {Styles.COLOR_BORDER};
+                border-radius: 6px;
+                padding: 2px 8px;
+                font-size: 12px;
+            }}
+            QLineEdit:focus {{
+                border-color: {Styles.COLOR_ACCENT};
+            }}
+        """)
+        self.engine_status_label.setStyleSheet(f"font-size: 11px; color: {Styles.COLOR_TEXT_MUTED}; padding: 2px 0px;")
+        self.captured_white.refresh_styles()
+        self.captured_black.refresh_styles()
+        for child in self.findChildren(QWidget):
+            child.style().unpolish(child)
+            child.style().polish(child)

--- a/src/gui/views/history_view.py
+++ b/src/gui/views/history_view.py
@@ -54,9 +54,9 @@ class HistoryView(QWidget):
         self.layout.addWidget(self.header_bar)
         
         # Content Container Widget
-        content_widget = QWidget()
-        content_widget.setStyleSheet(f"background-color: {Styles.COLOR_BACKGROUND};")
-        content_layout = QVBoxLayout(content_widget)
+        self.content_widget = QWidget()
+        self.content_widget.setStyleSheet(f"background-color: {Styles.COLOR_BACKGROUND};")
+        content_layout = QVBoxLayout(self.content_widget)
         content_layout.setContentsMargins(40, 20, 40, 20)
         content_layout.setSpacing(20)
         
@@ -156,7 +156,7 @@ class HistoryView(QWidget):
         
         content_layout.addLayout(btn_layout)
         
-        self.layout.addWidget(content_widget)
+        self.layout.addWidget(self.content_widget)
         
         # Load initial data
         self.load_history()
@@ -387,9 +387,10 @@ class HistoryView(QWidget):
             if not file_name:
                 return
                 
+            from src.gui.main_window import MainWindow
             history_games = self.history_manager.get_all_games()
             if not history_games:
-                QMessageBox.information(self, "No Games", "No games to export.")
+                MainWindow.toast_from_widget(self, "No games to export.", "warning")
                 return
 
             # Determine fields. We'll use database keys as headers.
@@ -406,7 +407,7 @@ class HistoryView(QWidget):
                     row = {k: game_dict.get(k) for k in fieldnames}
                     writer.writerow(row)
                     
-            QMessageBox.information(self, "Success", f"Exported {len(history_games)} games to {file_name}.")
+            MainWindow.toast_from_widget(self, f"Exported {len(history_games)} games.", "success")
             
         except Exception as e:
             logging.error(f"Export failed: {e}")
@@ -475,7 +476,7 @@ class HistoryView(QWidget):
                         logging.warning(f"Failed to parse row {game_id}: {row_e}")
                         
             self.load_history()
-            QMessageBox.information(self, "Import Complete", f"Imported: {imported_count}\nSkipped (Existing): {skipped_count}")
+            MainWindow.toast_from_widget(self, f"Imported: {imported_count}, Skipped: {skipped_count}", "success")
             
         except Exception as e:
             logging.error(f"Import failed: {e}")
@@ -570,6 +571,8 @@ class HistoryView(QWidget):
             """)
             
         # Cascade refresh to nested game list
+        if hasattr(self, 'content_widget') and self.content_widget:
+            self.content_widget.setStyleSheet(f"background-color: {Styles.COLOR_BACKGROUND};")
         if hasattr(self, 'game_list'):
             self.game_list.refresh_styles()
 

--- a/src/gui/views/metrics_view.py
+++ b/src/gui/views/metrics_view.py
@@ -78,6 +78,7 @@ class MetricsWidget(QWidget):
         
         # Content Area
         self.content_widget = QWidget()
+        self.content_widget.setStyleSheet(f"background-color: {Styles.COLOR_BACKGROUND};")
         self.content_layout = QVBoxLayout(self.content_widget)
         self.content_layout.setContentsMargins(40, 20, 40, 20)
         self.content_layout.setSpacing(20)
@@ -95,7 +96,11 @@ class MetricsWidget(QWidget):
 
         if hasattr(self, 'btn_refresh') and self.btn_refresh:
             self.btn_refresh.setStyleSheet(Styles.get_control_button_style())
-            
+
+        # Always update the content area background
+        if hasattr(self, 'content_widget') and self.content_widget:
+            self.content_widget.setStyleSheet(f"background-color: {Styles.COLOR_BACKGROUND};")
+
         if self.current_stats:
             saved_insights = self.current_insights
             clear_layout(self.content_layout)

--- a/src/gui/views/settings/api_settings.py
+++ b/src/gui/views/settings/api_settings.py
@@ -130,10 +130,10 @@ class ApiSettings(QGroupBox):
 
         # --- Profile selector row ---
         prof_row = QHBoxLayout()
-        lbl_prof = QLabel("LLM Profile:")
-        lbl_prof.setStyleSheet(lbl_style)
-        lbl_prof.setFixedWidth(88)
-        prof_row.addWidget(lbl_prof)
+        self._lbl_prof = QLabel("LLM Profile:")
+        self._lbl_prof.setStyleSheet(lbl_style)
+        self._lbl_prof.setFixedWidth(88)
+        prof_row.addWidget(self._lbl_prof)
 
         self.llm_profile_combo = QComboBox()
         self.llm_profile_combo.setStyleSheet(_combo_style)
@@ -173,13 +173,13 @@ class ApiSettings(QGroupBox):
         self.llm_profile_name.setStyleSheet(Styles.get_input_style())
         pf.addRow(self._lbl_pname, self.llm_profile_name)
 
-        lbl_prov = QLabel("Provider:"); lbl_prov.setStyleSheet(lbl_style)
+        self._lbl_prov = QLabel("Provider:"); self._lbl_prov.setStyleSheet(lbl_style)
         self.llm_provider_combo = QComboBox()
         for pkey, pmeta in self._llm_providers.items():
             self.llm_provider_combo.addItem(pmeta["label"], userData=pkey)
         self.llm_provider_combo.setStyleSheet(_combo_style)
         self.llm_provider_combo.currentIndexChanged.connect(self._on_provider_changed)
-        pf.addRow(lbl_prov, self.llm_provider_combo)
+        pf.addRow(self._lbl_prov, self.llm_provider_combo)
 
         self.lbl_llm_key = QLabel("API Key:"); self.lbl_llm_key.setStyleSheet(lbl_style)
         self.llm_key_input = QLineEdit()
@@ -187,10 +187,10 @@ class ApiSettings(QGroupBox):
         self.llm_key_input.setStyleSheet(Styles.get_input_style())
         pf.addRow(self.lbl_llm_key, self.llm_key_input)
 
-        lbl_model = QLabel("Model:"); lbl_model.setStyleSheet(lbl_style)
+        self._lbl_model = QLabel("Model:"); self._lbl_model.setStyleSheet(lbl_style)
         self.llm_model_input = QLineEdit()
         self.llm_model_input.setStyleSheet(Styles.get_input_style())
-        pf.addRow(lbl_model, self.llm_model_input)
+        pf.addRow(self._lbl_model, self.llm_model_input)
 
         self.lbl_llm_url = QLabel("Base URL:"); self.lbl_llm_url.setStyleSheet(lbl_style)
         self.llm_url_input = QLineEdit()
@@ -445,6 +445,15 @@ class ApiSettings(QGroupBox):
         self.llm_add_btn.setStyleSheet(llm_add_style)
         self.llm_del_btn.setStyleSheet(llm_del_style)
         self.llm_test_btn.setStyleSheet(default_style)
-        
         for widget in [self.llm_profile_name, self.llm_key_input, self.llm_model_input, self.llm_url_input, self.lichess_token_input]:
             widget.setStyleSheet(input_style)
+        # Refresh form row labels
+        lbl_style = f"color: {Styles.COLOR_TEXT_PRIMARY}; font-size: 13px; background: transparent;"
+        for lbl in [self._lbl_prof, self._lbl_pname, self._lbl_prov, self.lbl_llm_key,
+                    self._lbl_model, self.lbl_llm_url, self._lbl_lichess]:
+            if lbl:
+                lbl.setStyleSheet(lbl_style)
+        # Status labels
+        status_style = f"color: {Styles.COLOR_TEXT_SECONDARY}; font-size: 11px; background: transparent;"
+        self.llm_active_label.setStyleSheet(status_style)
+        self.llm_test_result.setStyleSheet(status_style)

--- a/src/gui/views/settings/appearance_settings.py
+++ b/src/gui/views/settings/appearance_settings.py
@@ -1,12 +1,35 @@
-"""
-Appearance Settings group component.
-"""
-from PyQt6.QtWidgets import QGroupBox, QFormLayout, QLabel, QComboBox, QCheckBox, QColorDialog
+from PyQt6.QtWidgets import QGroupBox, QFormLayout, QLabel, QComboBox, QCheckBox, QColorDialog, QRadioButton, QHBoxLayout, QWidget, QPushButton, QButtonGroup, QFrame
 from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtGui import QColor
 from ...styles import Styles
+from ...theme import ThemeManager
+from ...theme.palette import BOARD_THEMES
 from ....utils.path_utils import get_resource_path
 from .helpers import create_icon_button
+
+RADIO_GROUP_TPL = """
+    QRadioButton {{
+        color: {text};
+        font-size: 13px;
+        spacing: 8px;
+        padding: 4px 0;
+    }}
+    QRadioButton::indicator {{
+        width: 18px;
+        height: 18px;
+        border: 1px solid {border};
+        border-radius: 10px;
+        background: {bg};
+    }}
+    QRadioButton::indicator:checked {{
+        background: {accent};
+        border-color: {accent};
+    }}
+    QRadioButton::indicator:hover {{
+        border-color: {accent};
+    }}
+"""
+
 
 class AppearanceSettings(QGroupBox):
     theme_refreshed = pyqtSignal()
@@ -15,19 +38,22 @@ class AppearanceSettings(QGroupBox):
         super().__init__("Appearance", parent)
         self.config_manager = config_manager
         self.setStyleSheet(Styles.get_group_box_style())
-        
         self.setup_ui()
 
-    def setup_ui(self):
-        appearance_layout = QFormLayout(self)
-        appearance_layout.setContentsMargins(20, 30, 20, 20)
-        appearance_layout.setSpacing(16)
-        appearance_layout.setLabelAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
-        appearance_layout.setFormAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
-        appearance_layout.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow)
-        
-        label_style = f"color: {Styles.COLOR_TEXT_PRIMARY}; font-size: 14px; background: transparent;"
-        combo_style = f"""
+    def _radio_style(self):
+        p = ThemeManager.palette()
+        return RADIO_GROUP_TPL.format(
+            text=p.text_primary,
+            border=p.border,
+            bg=p.surface_light,
+            accent=p.accent,
+        )
+
+    def _label_style(self):
+        return f"color: {Styles.COLOR_TEXT_PRIMARY}; font-size: 14px; background: transparent;"
+
+    def _combo_style(self):
+        return f"""
             QComboBox {{
                 padding: 8px 12px;
                 min-width: 120px;
@@ -45,46 +71,96 @@ class AppearanceSettings(QGroupBox):
                 padding-right: 8px;
             }}
         """
-        
-        # Board Theme Selector
-        theme_lbl = QLabel("Board Theme:")
-        theme_lbl.setStyleSheet(label_style)
-        
+
+    def setup_ui(self):
+        layout = QFormLayout(self)
+        layout.setContentsMargins(20, 30, 20, 20)
+        layout.setSpacing(16)
+        layout.setLabelAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+
+        label_style = self._label_style()
+        combo_style = self._combo_style()
+        radio_style = self._radio_style()
+
+        self._add_theme_mode_row(layout, label_style, radio_style)
+        self._add_board_theme_row(layout, label_style, combo_style)
+        self._add_piece_style_row(layout, label_style, combo_style)
+        self._add_import_row(layout, label_style)
+        self._add_sound_row(layout, label_style)
+        self._add_accent_row(layout, label_style, radio_style)
+
+    def _make_radio_group(self, labels, parent, radio_style):
+        container = QWidget()
+        container.setStyleSheet("background: transparent;")
+        hbox = QHBoxLayout(container)
+        hbox.setContentsMargins(0, 0, 0, 0)
+        hbox.setSpacing(4)
+        group = QButtonGroup(container)
+        buttons = []
+        for label in labels:
+            rb = QRadioButton(label)
+            rb.setStyleSheet(radio_style)
+            group.addButton(rb)
+            hbox.addWidget(rb)
+            buttons.append(rb)
+        hbox.addStretch()
+        return group, buttons, container
+
+    def _add_theme_mode_row(self, layout, label_style, radio_style):
+        lbl = QLabel("Theme Mode:")
+        lbl.setStyleSheet(label_style)
+        group, buttons, container = self._make_radio_group(
+            ["System", "Light", "Dark"], self, radio_style
+        )
+        self._theme_mode_group = group
+        self._theme_mode_system, self._theme_mode_light, self._theme_mode_dark = buttons
+
+        saved = self.config_manager.get("theme_mode", "system")
+        idx = {"system": 0, "light": 1, "dark": 2}.get(saved, 0)
+        buttons[idx].setChecked(True)
+
+        group.buttonClicked.connect(self._on_theme_mode_clicked)
+        layout.addRow(lbl, container)
+
+    def _on_theme_mode_clicked(self, btn):
+        mapping = {self._theme_mode_system: "system", self._theme_mode_light: "light", self._theme_mode_dark: "dark"}
+        mode = mapping.get(btn, "system")
+        self.config_manager.config["theme_mode"] = mode
+        ThemeManager.set_theme_mode(mode)
+        self.theme_refreshed.emit()
+
+    def _add_board_theme_row(self, layout, label_style, combo_style):
+        lbl = QLabel("Board Theme:")
+        lbl.setStyleSheet(label_style)
         self.theme_combo = QComboBox()
-        self.theme_combo.addItems(list(Styles.BOARD_THEMES.keys()))
-        current_theme = self.config_manager.get("board_theme", "Green")
-        self.theme_combo.setCurrentText(current_theme)
+        self.theme_combo.addItems(list(BOARD_THEMES.keys()))
+        self.theme_combo.setCurrentText(self.config_manager.get("board_theme", "Green"))
         self.theme_combo.setStyleSheet(combo_style)
         self.theme_combo.currentTextChanged.connect(self.change_board_theme)
-        
-        appearance_layout.addRow(theme_lbl, self.theme_combo)
+        layout.addRow(lbl, self.theme_combo)
 
-        # Piece Style Selector
+    def _add_piece_style_row(self, layout, label_style, combo_style):
         from ...board.piece_themes import get_piece_theme_names
-        piece_lbl = QLabel("Piece Style:")
-        piece_lbl.setStyleSheet(label_style)
-        
+        lbl = QLabel("Piece Style:")
+        lbl.setStyleSheet(label_style)
         self.piece_combo = QComboBox()
         self.piece_combo.addItems(get_piece_theme_names())
-        current_piece_theme = self.config_manager.get("piece_theme", "Standard")
-        self.piece_combo.setCurrentText(current_piece_theme)
+        self.piece_combo.setCurrentText(self.config_manager.get("piece_theme", "Standard"))
         self.piece_combo.setStyleSheet(combo_style)
         self.piece_combo.currentTextChanged.connect(self.change_piece_theme)
-        
-        appearance_layout.addRow(piece_lbl, self.piece_combo)
+        layout.addRow(lbl, self.piece_combo)
 
-        # Import Theme button (spacer label keeps form alignment)
+    def _add_import_row(self, layout, label_style):
         import_lbl = QLabel("")
         import_lbl.setStyleSheet(label_style)
         self.import_theme_btn = create_icon_button(
             "Import Theme...", "fa5s.folder-open", self.import_theme, self
         )
-        appearance_layout.addRow(import_lbl, self.import_theme_btn)
+        layout.addRow(import_lbl, self.import_theme_btn)
 
-        # Sound Effects Selector
+    def _add_sound_row(self, layout, label_style):
         self._sound_lbl = QLabel("Sound Effects:")
         self._sound_lbl.setStyleSheet(label_style)
-        
         tick_path = get_resource_path("assets/images/tick.svg").replace("\\", "/")
         self.sound_checkbox = QCheckBox("Enable Sound Effects")
         self.sound_checkbox.setStyleSheet(f"""
@@ -92,10 +168,11 @@ class AppearanceSettings(QGroupBox):
                 color: {Styles.COLOR_TEXT_PRIMARY};
                 font-size: 13px;
                 background: transparent;
+                spacing: 8px;
             }}
             QCheckBox::indicator {{
-                width: 18px;
-                height: 18px;
+                width: 20px;
+                height: 20px;
                 border: 1px solid {Styles.COLOR_BORDER};
                 border-radius: 4px;
                 background-color: {Styles.COLOR_SURFACE_LIGHT};
@@ -108,80 +185,109 @@ class AppearanceSettings(QGroupBox):
         """)
         self.sound_checkbox.setChecked(self.config_manager.get("sound_enabled", True))
         self.sound_checkbox.stateChanged.connect(self.change_sound_setting)
-        
-        appearance_layout.addRow(self._sound_lbl, self.sound_checkbox)
+        layout.addRow(self._sound_lbl, self.sound_checkbox)
 
-        # Accent Color
-        color_lbl = QLabel("Accent Color:")
-        color_lbl.setStyleSheet(label_style)
-        
-        self.color_btn = create_icon_button("Change Color", "fa5s.palette", self.change_accent_color, self)
-        appearance_layout.addRow(color_lbl, self.color_btn)
+    def _add_accent_row(self, layout, label_style, radio_style):
+        accent_lbl = QLabel("Accent Color:")
+        accent_lbl.setStyleSheet(label_style)
+        container = QWidget()
+        container.setStyleSheet("background: transparent;")
+        hbox = QHBoxLayout(container)
+        hbox.setContentsMargins(0, 0, 0, 0)
+        hbox.setSpacing(4)
+        self._accent_group = QButtonGroup(container)
+        self.accent_mode_system = QRadioButton("System")
+        self.accent_mode_custom = QRadioButton("Custom")
+        for rb in (self.accent_mode_system, self.accent_mode_custom):
+            rb.setStyleSheet(radio_style)
+            self._accent_group.addButton(rb)
+            hbox.addWidget(rb)
+        self.color_btn = QPushButton("Choose Color")
+        self.color_btn.setStyleSheet(f"""
+            QPushButton {{
+                padding: 6px 14px;
+                background-color: {Styles.COLOR_SURFACE_LIGHT};
+                color: {Styles.COLOR_TEXT_PRIMARY};
+                border: 1px solid {Styles.COLOR_BORDER};
+                border-radius: 6px;
+                font-size: 13px;
+            }}
+            QPushButton:hover {{
+                border-color: {Styles.COLOR_ACCENT};
+            }}
+        """)
+        self.color_btn.clicked.connect(self.change_accent_color)
+        hbox.addWidget(self.color_btn)
+        hbox.addStretch()
+        saved = self.config_manager.get("accent_mode", "system")
+        if saved == "custom":
+            self.accent_mode_custom.setChecked(True)
+        else:
+            self.accent_mode_system.setChecked(True)
+        self._update_accent_btn_visibility()
+        self._accent_group.buttonClicked.connect(self._on_accent_mode_clicked)
+        layout.addRow(accent_lbl, container)
 
-    def change_accent_color(self):
-        color = QColorDialog.getColor(initial=QColor(Styles.COLOR_ACCENT), parent=self, title="Select Accent Color")
-        if color.isValid():
-            Styles.set_accent_color(color.name())
-            self.config_manager.config["accent_color"] = color.name()
-            self.theme_refreshed.emit()
-
-    def _update_config_and_refresh(self, key, value):
-        self.config_manager.config[key] = value
+    def _on_accent_mode_clicked(self, btn):
+        mode = "custom" if btn == self.accent_mode_custom else "system"
+        self.config_manager.config["accent_mode"] = mode
+        ThemeManager.set_accent_mode(mode)
+        self._update_accent_btn_visibility()
         self.theme_refreshed.emit()
 
+    def _update_accent_btn_visibility(self):
+        self.color_btn.setVisible(self.accent_mode_custom.isChecked())
+
+    def change_accent_color(self):
+        color = QColorDialog.getColor(initial=QColor(ThemeManager.accent()), parent=self, title="Select Accent Color")
+        if color.isValid():
+            ThemeManager.set_accent(color.name())
+            self.config_manager.config["accent_color"] = color.name()
+            self.config_manager.config["accent_mode"] = "custom"
+            self.accent_mode_custom.setChecked(True)
+            self._update_accent_btn_visibility()
+            self.theme_refreshed.emit()
+
     def change_board_theme(self, theme_name):
-        self._update_config_and_refresh("board_theme", theme_name)
+        self.config_manager.config["board_theme"] = theme_name
+        self.theme_refreshed.emit()
 
     def change_piece_theme(self, theme_name):
-        self._update_config_and_refresh("piece_theme", theme_name)
+        self.config_manager.config["piece_theme"] = theme_name
+        self.theme_refreshed.emit()
 
     def change_sound_setting(self, state):
         self.config_manager.config["sound_enabled"] = self.sound_checkbox.isChecked()
 
     def import_theme(self):
         from PyQt6.QtWidgets import QFileDialog, QMessageBox
+        from src.gui.main_window import MainWindow
         from ...board.piece_themes import (
             get_piece_theme_names,
             import_theme_from_folder,
             validate_theme_folder,
         )
-
         folder = QFileDialog.getExistingDirectory(
             self, "Select Piece Theme Folder", "",
             QFileDialog.Option.ShowDirsOnly,
         )
         if not folder:
             return
-
         is_valid, errors = validate_theme_folder(folder)
         if not is_valid:
-            QMessageBox.warning(
-                self, "Invalid Theme",
-                "The selected folder is not a valid piece theme:\n\n"
-                + "\n".join(errors),
-            )
+            QMessageBox.warning(self, "Invalid Theme", "The selected folder is not a valid piece theme:\n\n" + "\n".join(errors))
             return
-
         theme_name = import_theme_from_folder(folder)
         if theme_name is None:
-            QMessageBox.critical(
-                self, "Import Failed",
-                "Failed to import the theme. Check the logs for details.",
-            )
+            QMessageBox.critical(self, "Import Failed", "Failed to import the theme. Check the logs for details.")
             return
-
         self.piece_combo.blockSignals(True)
         self.piece_combo.clear()
         self.piece_combo.addItems(get_piece_theme_names())
         self.piece_combo.setCurrentText(theme_name)
         self.piece_combo.blockSignals(False)
-
         self.change_piece_theme(theme_name)
-
-        QMessageBox.information(
-            self, "Theme Imported",
-            f"Piece theme '{theme_name}' has been imported and is now active.",
-        )
+        MainWindow.toast_from_widget(self, f"Piece theme '{theme_name}' imported and active.", "success")
 
     def set_advanced_visible(self, visible):
         pass
@@ -193,3 +299,8 @@ class AppearanceSettings(QGroupBox):
         self.sound_checkbox.setStyleSheet(sound_cb_style)
         self.color_btn.setStyleSheet(default_style)
         self.import_theme_btn.setStyleSheet(default_style)
+        rs = self._radio_style()
+        for btn in (self._theme_mode_system, self._theme_mode_light, self._theme_mode_dark,
+                    self.accent_mode_system, self.accent_mode_custom):
+            if btn:
+                btn.setStyleSheet(rs)

--- a/src/gui/views/settings/data_settings.py
+++ b/src/gui/views/settings/data_settings.py
@@ -30,7 +30,8 @@ class DataSettings(QGroupBox):
             from src.backend.storage.cache import AnalysisCache
             cache = AnalysisCache()
             cache.clear_cache()
-            QMessageBox.information(self, "Success", "Analysis cache cleared.")
+            from src.gui.main_window import MainWindow
+            MainWindow.toast_from_widget(self, "Analysis cache cleared.", "success")
 
     def clear_all_data(self):
         reply = QMessageBox.question(self, "Confirm", "Are you sure you want to clear ALL data? This includes game history and analysis cache. This action cannot be undone.",
@@ -54,7 +55,8 @@ class DataSettings(QGroupBox):
                 if hasattr(window, "metrics_view"):
                     window.metrics_view.refresh([])
             
-            QMessageBox.information(self, "Success", "All data cleared.")
+            from src.gui.main_window import MainWindow
+            MainWindow.toast_from_widget(self, "All data cleared.", "success")
 
     def set_advanced_visible(self, visible):
         self.setVisible(visible)

--- a/src/gui/views/settings/engine_settings.py
+++ b/src/gui/views/settings/engine_settings.py
@@ -115,10 +115,10 @@ class EngineSettings(QGroupBox):
         self.depth_combo.setCurrentText(str(self.config_manager.get("analysis_depth", DEFAULT_ANALYSIS_DEPTH)))
         self.depth_combo.setStyleSheet(combo_style)
         self.depth_combo.currentTextChanged.connect(self.change_analysis_depth)
-        depth_lbl, depth_row = _wrap(
+        self._depth_lbl, depth_row = _wrap(
             "Analysis Depth:", self.depth_combo, "(Higher = more accurate but slower)"
         )
-        form.addRow(depth_lbl, depth_row)
+        form.addRow(self._depth_lbl, depth_row)
 
         # --- Multi-PV (alt lines per move) ---
         self.multi_pv_input = QLineEdit()
@@ -360,3 +360,9 @@ class EngineSettings(QGroupBox):
         for widget in [self.multi_pv_input, self.live_time_input, self.threads_input, self.hash_input]:
             widget.setStyleSheet(input_style)
         self.path_input.setStyleSheet(input_style.replace("max-width: 140px;", ""))
+        # Refresh form row labels
+        lbl_style = f"color: {Styles.COLOR_TEXT_PRIMARY}; font-size: 13px; background: transparent;"
+        for lbl in [self._depth_lbl, self._multi_pv_lbl, self._live_time_lbl,
+                    self._threads_lbl, self._hash_lbl]:
+            if lbl:
+                lbl.setStyleSheet(lbl_style)

--- a/src/gui/views/settings/links_settings.py
+++ b/src/gui/views/settings/links_settings.py
@@ -54,11 +54,8 @@ class LinksSettings(QGroupBox):
                 dialog = UpdateNotificationDialog(update_info, self)
                 dialog.exec()
             else:
-                QMessageBox.information(
-                    self, 
-                    "Up to Date", 
-                    f"You're running the latest version (v{APP_VERSION})."
-                )
+                from src.gui.main_window import MainWindow
+                MainWindow.toast_from_widget(self, f"You're up to date (v{APP_VERSION}).", "success")
         except Exception as e:
             QMessageBox.warning(self, "Error", f"Failed to check for updates: {e}")
         finally:

--- a/src/gui/views/settings/player_settings.py
+++ b/src/gui/views/settings/player_settings.py
@@ -29,11 +29,11 @@ class PlayerSettings(QGroupBox):
         self.lichess_input.setPlaceholderText("Lichess.org Username")
         self.lichess_input.setStyleSheet(Styles.get_input_style())
 
-        lbl_chesscom = QLabel("Chess.com:")
-        lbl_chesscom.setStyleSheet(f"color: {Styles.COLOR_TEXT_PRIMARY}; font-size: 13px; background: transparent;")
+        self._lbl_chesscom = QLabel("Chess.com:")
+        self._lbl_chesscom.setStyleSheet(f"color: {Styles.COLOR_TEXT_PRIMARY}; font-size: 13px; background: transparent;")
         
-        lbl_lichess_user = QLabel("Lichess.org:")
-        lbl_lichess_user.setStyleSheet(f"color: {Styles.COLOR_TEXT_PRIMARY}; font-size: 13px; background: transparent;")
+        self._lbl_lichess_user = QLabel("Lichess.org:")
+        self._lbl_lichess_user.setStyleSheet(f"color: {Styles.COLOR_TEXT_PRIMARY}; font-size: 13px; background: transparent;")
 
         self.games_limit_input = QLineEdit()
         self.games_limit_input.setValidator(QIntValidator(1, 30, self.games_limit_input))
@@ -44,8 +44,8 @@ class PlayerSettings(QGroupBox):
         self._lbl_games_limit = QLabel("Games Fetch Limit:")
         self._lbl_games_limit.setStyleSheet(f"color: {Styles.COLOR_TEXT_PRIMARY}; font-size: 13px; background: transparent;")
 
-        username_layout.addRow(lbl_chesscom, self.chesscom_input)
-        username_layout.addRow(lbl_lichess_user, self.lichess_input)
+        username_layout.addRow(self._lbl_chesscom, self.chesscom_input)
+        username_layout.addRow(self._lbl_lichess_user, self.lichess_input)
         username_layout.addRow(self._lbl_games_limit, self.games_limit_input)
 
     def reload_from_config(self):
@@ -62,3 +62,8 @@ class PlayerSettings(QGroupBox):
         self.games_limit_input.setStyleSheet(input_style)
         self.chesscom_input.setStyleSheet(full_input_style)
         self.lichess_input.setStyleSheet(full_input_style)
+        # Refresh form row labels
+        lbl_style = f"color: {Styles.COLOR_TEXT_PRIMARY}; font-size: 13px; background: transparent;"
+        for lbl in [self._lbl_chesscom, self._lbl_lichess_user, self._lbl_games_limit]:
+            if lbl:
+                lbl.setStyleSheet(lbl_style)

--- a/src/gui/views/settings_view.py
+++ b/src/gui/views/settings_view.py
@@ -221,6 +221,23 @@ class SettingsView(QWidget):
         if HAS_QTAWESOME:
             icon_name = "fa5s.cog" if self._mode == "basic" else "fa5s.chevron-left"
             b.setIcon(qta.icon(icon_name, color=Styles.COLOR_TEXT_SECONDARY))
+        # Always re-apply the themed stylesheet
+        b.setStyleSheet(f"""
+            QPushButton {{
+                background-color: {Styles.COLOR_SURFACE_LIGHT};
+                color: {Styles.COLOR_TEXT_SECONDARY};
+                border: 1px solid {Styles.COLOR_BORDER};
+                padding: 8px 16px;
+                border-radius: 6px;
+                font-size: 12px;
+                font-weight: 500;
+            }}
+            QPushButton:hover {{
+                background-color: {Styles.COLOR_SURFACE};
+                color: {Styles.COLOR_ACCENT};
+                border-color: {Styles.COLOR_ACCENT};
+            }}
+        """)
 
     def _toggle_mode(self):
         self._mode = "advanced" if self._mode == "basic" else "basic"
@@ -350,10 +367,11 @@ class SettingsView(QWidget):
         self.book_settings.validate_polyglot_path()
         self.api_settings._reload_profile_combo()
 
+        from src.gui.main_window import MainWindow
         if clamped:
             QMessageBox.warning(self, "Limit Capped", f"Settings saved successfully.\n\nNote: {warning_msg}")
         else:
-            QMessageBox.information(self, "Saved", "All settings saved successfully.")
+            MainWindow.toast_from_widget(self, "All settings saved successfully.", "success")
 
     def save_usernames(self):
         chesscom = self.chesscom_input.text()
@@ -387,10 +405,11 @@ class SettingsView(QWidget):
         self.config_manager.set("api_games_limit", limit)
         self.usernames_changed.emit()
 
+        from src.gui.main_window import MainWindow
         if clamped:
             QMessageBox.warning(self, "Limit Capped", warning_msg)
         else:
-            QMessageBox.information(self, "Saved", "Settings saved successfully.")
+            MainWindow.toast_from_widget(self, "Settings saved successfully.", "success")
 
     def refresh_styles(self):
         """Re-applies styles to all widgets."""
@@ -401,7 +420,17 @@ class SettingsView(QWidget):
                     border-bottom: 1px solid {Styles.COLOR_BORDER};
                 }}
             """)
-        
+
+        # Update scroll area and content container backgrounds
+        if hasattr(self, 'scroll_area') and self.scroll_area:
+            self.scroll_area.setStyleSheet(f"background-color: {Styles.COLOR_BACKGROUND}; border: none;")
+        if hasattr(self, 'content_container') and self.content_container:
+            self.content_container.setStyleSheet(f"background-color: {Styles.COLOR_BACKGROUND};")
+
+        # Refresh mode toggle button
+        if hasattr(self, 'mode_toggle_btn') and self.mode_toggle_btn:
+            self._update_mode_toggle_text(self.mode_toggle_btn)
+
         primary_style = f"""
             QPushButton {{
                 background-color: {Styles.COLOR_ACCENT};

--- a/tests/gui/test_settings_view.py
+++ b/tests/gui/test_settings_view.py
@@ -45,9 +45,7 @@ def test_settings_view_clamping_with_token(qapp, qtbot, isolated_config):
         view.lichess_token_input.setText("test_token")
         view.games_limit_input.setText("25")
         
-        with patch.object(QMessageBox, "information") as mock_info:
-            view.save_usernames()
-            mock_info.assert_called_once()
+        view.save_usernames()
             
         assert view.config_manager.get("api_games_limit") == 25
         assert view.games_limit_input.text() == "25"
@@ -85,9 +83,7 @@ def test_save_all_settings_flow(qapp, qtbot, isolated_config):
         view.llm_config_changed = MagicMock()
         view.usernames_changed = MagicMock()
         
-        with patch.object(QMessageBox, "information") as mock_info:
-            view.save_all_settings()
-            mock_info.assert_called_once()
+        view.save_all_settings()
             
         # Verify changes are stored in the config
         assert view.config_manager.get("engine_path") == "mock-stockfish"


### PR DESCRIPTION
## Summary

Implement theme system with light/dark mode support, accent color detection, and full widget refresh on theme switch.

## Changes

### Theme infrastructure
- Add `ThemeManager` module with palette definitions, tokens, macOS system accent detection
- `Styles` class delegates all color constants to `ThemeManager.palette()` for dynamic resolution
- Add `QPalette` sync via `_apply_palette()` for native widget styling
- Add real-time `theme_changed`/`accent_changed` signals wired to `refresh_theme()`

### New components
- `Toast` — notification widget with solid background, colored border, fade animation
- `FadedStackedWidget` — crossfade page transitions replacing `QStackedWidget`

### Widget refresh methods
Add `refresh_styles()` to all widgets with explicit `setStyleSheet()`:

- **Analysis:** `AnalysisLinesWidget`, `CapturedPiecesWidget`, `GameControlsWidget`, `ExplorerMoveListWidget`, `MoveCellWidget`, `MoveListPanel`, `AnalysisPanel`
- **Views:** `ExplorerView`, `HistoryView`, `MetricsView`, `SettingsView` + all 6 settings sub-widgets
- **Components:** `Sidebar`, `StatCard`, `GraphWidget`, `SourceBtn`
- **Dialogs:** `LoadGameDialog`, `DropZone`

Each method re-applies its stylesheet using current palette colors from `Styles.COLOR_*`.

### Color fixes
- `MoveCellWidget`: Remove hardcoded white colors, use `Styles.COLOR_TEXT_PRIMARY`/`COLOR_TEXT_MUTED`/`COLOR_SURFACE_LIGHT`

### Sidebar
- `apply_style()` for theme-aware icon/text/background rendering

### Test fixes
- Update 2 tests that expected `QMessageBox.information` (code uses `MainWindow.toast_from_widget` now)

## Test Results
202 passed, 1 failed